### PR TITLE
Fix LabelEditor empty value bug

### DIFF
--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -569,7 +569,10 @@ class ComponentEditor extends Component<
           configurationId,
           device,
           extensionName: editor.editTreePath,
-          label: this.state.newLabel || configuration!.label,
+          label:
+            this.state.newLabel !== undefined
+              ? this.state.newLabel
+              : configuration!.label,
           path: iframeWindow.location.pathname,
           propsJSON: JSON.stringify(pickedProps),
           routeId: this.getDecodedRouteId(configuration!.scope, runtime.page),
@@ -754,7 +757,9 @@ class ComponentEditor extends Component<
           <LabelEditor
             onChange={this.handleConfigurationLabelChange}
             value={
-              this.state.newLabel || (configuration && configuration.label)
+              this.state.newLabel !== undefined
+                ? this.state.newLabel
+                : configuration && configuration.label
             }
           />
           <div className="mt5">


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Replace generic check for falsy values with explicit one for `undefined`.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Currently, the user cannot delete a previously set configuration name. This PR addresses that issue.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)