### PR TITLE
Added Array of Array support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.3] - 2018-08-28
 ### Fixed
 - Array of Array rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Array of Array rendering.
 
 ## [2.1.2] - 2018-08-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/form/ArrayFieldTemplate.js
+++ b/react/components/form/ArrayFieldTemplate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Fragment, Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { SortableContainer } from 'react-sortable-hoc'
 import { Button } from 'vtex.styleguide'
 
@@ -14,22 +14,27 @@ function getHelperDimensions({ node }) {
   }
 }
 
-const ArrayList = SortableContainer(({ items, schema, openedItem, onOpen, onClose, sorting }) => (
-  <div className={`accordion-list-container ${sorting ? 'accordion-list-container--sorting' : ''}`}>
-    {items.map(element => (
-      <ArrayFieldTemplateItem
-        key={element.index}
-        schema={schema}
-        isOpen={openedItem === element.index}
-        onOpen={onOpen(element.index)}
-        onClose={onClose}
-        formIndex={element.index}
-        showDragHandle={items.length > 1}
-        {...element}
-      />
-    ))}
-  </div>
-))
+const ArrayList = SortableContainer(
+  ({ items, schema, openedItem, onOpen, onClose, sorting }) => (
+    <div
+      className={`accordion-list-container ${
+        sorting ? 'accordion-list-container--sorting' : ''
+      }`}>
+      {items.map(element => (
+        <ArrayFieldTemplateItem
+          key={element.index}
+          schema={schema}
+          isOpen={openedItem === element.index}
+          onOpen={onOpen(element.index)}
+          onClose={onClose}
+          formIndex={element.index}
+          showDragHandle={items.length > 1}
+          {...element}
+        />
+      ))}
+    </div>
+  )
+)
 
 class ArrayFieldTemplate extends Component {
   static propTypes = {
@@ -40,7 +45,7 @@ class ArrayFieldTemplate extends Component {
   }
 
   state = {
-    openedItem: 0,
+    openedItem: null,
   }
 
   handleOpen = index => e => {
@@ -111,8 +116,7 @@ class ArrayFieldTemplate extends Component {
             <Button
               variation="secondary"
               size="small"
-              onClick={this.handleAddItem}
-            >
+              onClick={this.handleAddItem}>
               + Add More
             </Button>
           )}

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react'
 import { SortableElement, SortableHandle } from 'react-sortable-hoc'
 import { Transition } from 'react-spring'
 
-import TrashSimple from '../icons/TrashSimple'
 import DragHandle from '../icons/DragHandle'
+import TrashSimple from '../icons/TrashSimple'
 
 const stopPropagation = fn => e => {
   e.stopPropagation()
@@ -28,6 +28,10 @@ class ArrayFieldTemplateItem extends Component {
     showDragHandle: PropTypes.bool,
   }
 
+  state = {
+    autoHeight: false,
+  }
+
   handleLabelClick = e => {
     const { isOpen, onOpen, onClose } = this.props
 
@@ -40,9 +44,12 @@ class ArrayFieldTemplateItem extends Component {
 
   renderChildren = styles => {
     const { children } = this.props
-
     return (
-      <div style={styles}>
+      <div
+        style={{
+          ...styles,
+          height: this.state.autoHeight ? 'auto' : styles.height,
+        }}>
         {children}
       </div>
     )
@@ -59,37 +66,41 @@ class ArrayFieldTemplateItem extends Component {
       showDragHandle,
     } = this.props
 
-    const title = children.props.formData.__editorItemTitle || schema.items.properties.__editorItemTitle.default
+    const title =
+      children.props.formData.__editorItemTitle ||
+      schema.items.properties.__editorItemTitle.default
 
     return (
-      <div className={`accordion-item bb b--light-silver ${showDragHandle ? '' : 'accordion-item--handle-hidden'}`}>
+      <div
+        className={`accordion-item bb b--light-silver ${
+          showDragHandle ? '' : 'accordion-item--handle-hidden'
+        }`}>
         <div className="accordion-label" onClick={this.handleLabelClick}>
           <div className="flex items-center">
             {showDragHandle && <Handle />}
-            <label className="f6 accordion-label-title">
-              {title}
-            </label>
+            <label className="f6 accordion-label-title">{title}</label>
           </div>
           <div className="flex items-center accordion-label-buttons">
             {hasRemove && (
               <button
                 className="accordion-icon-button accordion-icon-button--remove"
-                onClick={stopPropagation(onDropIndexClick(formIndex))}
-              >
+                onClick={stopPropagation(onDropIndexClick(formIndex))}>
                 <TrashSimple size={15} />
               </button>
             )}
           </div>
         </div>
         <div
-          className={`accordion-content ${isOpen ? 'accordion-content--open' : ''}`}
-        >
+          className={`accordion-content ${
+            isOpen ? 'accordion-content--open' : ''
+          }`}>
           <Transition
             keys={isOpen ? ['children'] : []}
             from={{ opacity: 0, height: 0 }}
             enter={{ opacity: 1, height: 'auto' }}
             leave={{ opacity: 0, height: 0 }}
-          >
+            onRest={() => this.setState({ autoHeight: true })}
+            onStart={() => this.setState({ autoHeight: false })}>
             {isOpen ? [this.renderChildren] : []}
           </Transition>
         </div>

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -28,7 +28,9 @@ class ArrayFieldTemplateItem extends Component {
     showDragHandle: PropTypes.bool,
   }
 
-  autoHeight = false
+  state = {
+    autoHeight: false,
+  }
 
   handleLabelClick = e => {
     const { isOpen, onOpen, onClose } = this.props
@@ -41,11 +43,15 @@ class ArrayFieldTemplateItem extends Component {
   }
 
   handleOnRest = () => {
-    this.autoHeight = true
+    if (!this.state.autoHeight) {
+      this.setState({ autoHeight: true })
+    }
   }
 
   handleOnStart = () => {
-    this.autoHeight = false
+    if (this.state.autoHeight) {
+      this.setState({ autoHeight: false })
+    }
   }
 
   renderChildren = styles => {
@@ -54,7 +60,7 @@ class ArrayFieldTemplateItem extends Component {
       <div
         style={{
           ...styles,
-          height: this.autoHeight ? 'auto' : styles.height,
+          height: this.state.autoHeight ? 'auto' : styles.height,
         }}>
         {children}
       </div>

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -28,9 +28,7 @@ class ArrayFieldTemplateItem extends Component {
     showDragHandle: PropTypes.bool,
   }
 
-  state = {
-    autoHeight: false,
-  }
+  autoHeight = false
 
   handleLabelClick = e => {
     const { isOpen, onOpen, onClose } = this.props
@@ -48,7 +46,7 @@ class ArrayFieldTemplateItem extends Component {
       <div
         style={{
           ...styles,
-          height: this.state.autoHeight ? 'auto' : styles.height,
+          height: this.autoHeight ? 'auto' : styles.height,
         }}>
         {children}
       </div>
@@ -99,8 +97,8 @@ class ArrayFieldTemplateItem extends Component {
             from={{ opacity: 0, height: 0 }}
             enter={{ opacity: 1, height: 'auto' }}
             leave={{ opacity: 0, height: 0 }}
-            onRest={() => this.setState({ autoHeight: true })}
-            onStart={() => this.setState({ autoHeight: false })}>
+            onRest={() => (this.autoHeight = true)}
+            onStart={() => (this.autoHeight = false)}>
             {isOpen ? [this.renderChildren] : []}
           </Transition>
         </div>

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -40,6 +40,14 @@ class ArrayFieldTemplateItem extends Component {
     }
   }
 
+  handleOnRest = () => {
+    this.autoHeight = true
+  }
+
+  handleOnStart = () => {
+    this.autoHeight = false
+  }
+
   renderChildren = styles => {
     const { children } = this.props
     return (
@@ -97,8 +105,8 @@ class ArrayFieldTemplateItem extends Component {
             from={{ opacity: 0, height: 0 }}
             enter={{ opacity: 1, height: 'auto' }}
             leave={{ opacity: 0, height: 0 }}
-            onRest={() => (this.autoHeight = true)}
-            onStart={() => (this.autoHeight = false)}>
+            onRest={this.handleOnRest}
+            onStart={this.handleOnStart}>
             {isOpen ? [this.renderChildren] : []}
           </Transition>
         </div>

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -1,10 +1,11 @@
 @import '~react-select/dist/react-select.css';
 
-html, body {
+html,
+body {
   height: 100%;
 }
 
-.track-1{
+.track-1 {
   letter-spacing: 0.2px;
 }
 
@@ -26,9 +27,9 @@ html, body {
 }
 
 .shadow-editor {
-  -webkit-box-shadow: 0px -2px 1px 0px rgba(0,0,0,0.25);
-  -moz-box-shadow: 0px -2px 1px 0px rgba(0,0,0,0.25);
-  box-shadow: 0px -2px 1px 0px rgba(0,0,0,0.25);
+  -webkit-box-shadow: 0px -2px 1px 0px rgba(0, 0, 0, 0.25);
+  -moz-box-shadow: 0px -2px 1px 0px rgba(0, 0, 0, 0.25);
+  box-shadow: 0px -2px 1px 0px rgba(0, 0, 0, 0.25);
 }
 
 .form-group {
@@ -37,8 +38,8 @@ html, body {
 }
 
 .form-group.field.field-object > label {
-  border-top: 2px solid #F0F2F4;
-  color: #C3C4C5;
+  border-top: 2px solid #f0f2f4;
+  color: #c3c4c5;
   font-weight: 700;
   margin-top: 10px;
   padding: 20px 0px 5px;
@@ -74,12 +75,12 @@ html, body {
 }
 
 .form-control {
-  border: 2px solid #E1E3E5;
+  border: 2px solid #e1e3e5;
   height: 40px;
   width: 100%;
   font-size: 14px;
   padding-left: 12px;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .draggable {
@@ -157,15 +158,14 @@ html, body {
   }
   .form-schema {
     min-height: 300px;
-    max-height: 60vh;
   }
   .size-editor {
     max-width: 450px;
   }
   .shadow-editor-desktop {
-    -webkit-box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
-    -moz-box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
-    box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
+    -webkit-box-shadow: 0px 4px 10px 0px rgba(86, 88, 107, 0.5);
+    -moz-box-shadow: 0px 4px 10px 0px rgba(86, 88, 107, 0.5);
+    box-shadow: 0px 4px 10px 0px rgba(86, 88, 107, 0.5);
   }
 }
 
@@ -221,18 +221,18 @@ html, body {
   width: 360px;
   height: 640px;
   overflow-x: hidden;
-  box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.20);
+  box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .tablet-preview {
   width: 768px;
   height: 1024px;
   overflow-x: hidden;
-  box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.20);
+  box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .stroke-blue {
-  stroke: #368DF7;
+  stroke: #368df7;
 }
 
 .stroke-mid-gray {
@@ -240,7 +240,7 @@ html, body {
 }
 
 .fill-blue {
-  fill: #368DF7;
+  fill: #368df7;
 }
 
 .fill-mid-gray {
@@ -271,9 +271,17 @@ html, body {
   user-select: none;
 }
 
+.accordion-content .accordion-label {
+  margin-left: 0;
+}
+
+.accordion-content .accordion-content {
+  padding-left: 14px;
+}
+
 .accordion-item--dragged .accordion-label,
 .accordion-label:hover {
-  background-color: #F2F4F5;
+  background-color: #f2f4f5;
   padding-left: 26px;
 }
 
@@ -282,7 +290,7 @@ html, body {
 }
 
 .accordion-item--dragged .accordion-label {
-  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2);
+  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.2);
 }
 
 .accordion-label-buttons {
@@ -326,12 +334,12 @@ html, body {
 
 .accordion-icon-button:hover .editor-icon--stroke path,
 .accordion-icon-button:hover .editor-icon--stroke circle {
-  stroke: #368DF7;
+  stroke: #368df7;
 }
 
 .accordion-icon-button:hover .editor-icon--fill path,
 .accordion-icon-button:hover .editor-icon--fill circle {
-  fill: #368DF7;
+  fill: #368df7;
 }
 
 .accordion-handle {
@@ -344,10 +352,6 @@ html, body {
 .accordion-item--dragged .accordion-handle,
 .accordion-label:hover .accordion-handle {
   display: block;
-}
-
-.accordion-content {
-  overflow: hidden;
 }
 
 .accordion-item--dragged .accordion-content {


### PR DESCRIPTION
#### What is the purpose of this pull request?
The CMS didn't support the array of array type and now it's needed.

#### What problem is this solving?
For example, the [Footer Component](https://github.com/vtex-apps/store-components/blob/master/react/components/Footer/index.js) has a property called sectionLinks. This property has an array of sections. Each section has an array of links. The Admin Pages didn't support it properly.

#### How should this be manually tested?

[See it in my workspace](https://estacio--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

##### Before
![image](https://user-images.githubusercontent.com/15948386/44552248-1214ed00-a700-11e8-9995-56905caef977.png)

##### After
![image](https://user-images.githubusercontent.com/15948386/44552277-2953da80-a700-11e8-8c37-435e39345594.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
