### PR TITLE
Deep uiSchema now gets array items.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules/
 docs/_book/
 .tmp
 .idea
+.vscode
 npm-debug.log
 .build/
 lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Deep uiSchema now gets array items.
 
 ## [2.2.1] - 2018-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.2] - 2018-09-05
 ### Fixed
 - Deep uiSchema now gets array items.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -1,14 +1,4 @@
-import {
-  filter,
-  has,
-  keys,
-  map,
-  merge,
-  mergeDeepLeft,
-  pick,
-  pickBy,
-  reduce,
-} from 'ramda'
+import { filter, has, keys, map, merge, mergeDeepLeft, path, pick, pickBy, reduce } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import { compose, graphql } from 'react-apollo'
 import { injectIntl } from 'react-intl'
@@ -32,7 +22,6 @@ import TextArea from '../form/TextArea'
 import Toggle from '../form/Toggle'
 import Modal from '../Modal'
 import ModeSwitcher from '../ModeSwitcher'
-
 import ConfigurationsList from './ConfigurationsList'
 import LabelEditor from './LabelEditor'
 import SaveButton from './SaveButton'
@@ -260,8 +249,8 @@ class ComponentEditor extends Component<
         properties,
       )
       const itemsProperties = pickBy(
-        property => has('items', property),
-        properties,
+        property => has('properties', property),
+        properties.items
       )
 
       return {
@@ -275,7 +264,10 @@ class ComponentEditor extends Component<
             deepProperties,
           )),
         ...(itemsProperties &&
-          map(item => getDeepUiSchema(item), itemsProperties)),
+          map(
+            item => getDeepUiSchema(item),
+            itemsProperties)
+          ),
       }
     }
 
@@ -290,6 +282,13 @@ class ComponentEditor extends Component<
           property => has('properties', property),
           componentSchema.properties,
         ),
+      ),
+      ...map(
+        property => getDeepUiSchema(property),
+        pickBy(
+          property => has('items', property),
+          componentSchema.properties
+        )
       ),
     }
 

--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -266,8 +266,9 @@ class ComponentEditor extends Component<
         ...(itemsProperties &&
           map(
             item => getDeepUiSchema(item),
-            itemsProperties)
-          ),
+            itemsProperties
+          )
+        ),
       }
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Deep uiSchema now gets array items.

#### What problem is this solving?
It wasn't possible to set widgets inside array items.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/44998354-59666d80-af8b-11e8-90bc-3b94818c67ca.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
