### PR TITLE
Fix - Redirect list cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.3] - 2018-09-11
 ### Added
 - **Redirects Admin**
   - Periods to empty state i18n texts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,56 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Redirects Admin**
+  - Periods to empty state i18n texts.
+
+### Fixed
+- **Redirects Admin**
+  - Apollo cache/fetch logic.
+
+### Removed
+- **Redirects Admin**
+  - Some `console.log`s.
+  - Loading from remove button outside of modal.
 
 ## [2.2.2] - 2018-09-05
 ### Fixed
 - Deep uiSchema now gets array items.
 
 ## [2.2.1] - 2018-09-04
+### Changed
+- **Redirects Admin**
+  - Hide `Pagination` @ empty state.
+
+### Fixed
+- **Redirects Admin**
+  - Pagination `to` edge case.
 
 ## [2.2.0] - 2018-09-04
+### Added
+- **Admins**
+  - I18n to loading text.
+
+- **Redirects Admin**
+  - Pagination to redirect list.
+  - Confirmation modal before deleting a redirect.
+  - End date to redirect form and list.
+  - Status to redirect list.
+  - Sublink to redirect list to admin.
+
+### Changed
+- **Redirects Admin**
+  - Split redirects components into separate routes.
+  - Make `Modal` more generic and move it to `components/`.
+  - Bump Styleguide to 6.x.
+
+### Fixed
+- **`ComponentEditor`**
+  - Save button rendering behavior @ new configs.
+
+- **`LabelEditor`**
+  - Empty value bug.
 
 ## [2.1.3] - 2018-08-28
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/Admin/Redirects/RedirectForm/Form.tsx
+++ b/react/components/Admin/Redirects/RedirectForm/Form.tsx
@@ -171,7 +171,6 @@ class Form extends Component<Props, State> {
                 </div>
                 {this.isViewMode ? (
                   <Button
-                    isLoading={isLoading}
                     size="small"
                     onClick={this.toggleModalVisibility}
                     variation="danger"

--- a/react/components/Admin/Redirects/RedirectForm/Form.tsx
+++ b/react/components/Admin/Redirects/RedirectForm/Form.tsx
@@ -203,13 +203,11 @@ class Form extends Component<Props, State> {
 
     this.setState({ isLoading: true }, async () => {
       try {
-        const data = await onDelete({
+        await onDelete({
           variables: {
             id: redirectId,
           },
         })
-
-        console.log('OK!', data)
 
         this.exit()
       } catch (err) {
@@ -242,15 +240,13 @@ class Form extends Component<Props, State> {
 
     this.setState({ isLoading: true }, async () => {
       try {
-        const data = await onSave({
+        await onSave({
           variables: {
             endDate,
             from,
             to,
           },
         })
-
-        console.log('OK!', data)
 
         this.exit()
       } catch (err) {

--- a/react/components/Admin/Redirects/RedirectForm/typings.d.ts
+++ b/react/components/Admin/Redirects/RedirectForm/typings.d.ts
@@ -1,3 +1,5 @@
+import { RedirectsQuery } from '../typings'
+
 export interface MutationResult {
   data?: {
     [name: string]: Redirect
@@ -8,11 +10,4 @@ export type QueryData = RedirectsQuery | null
 
 export interface RedirectQuery {
   redirect?: Redirect
-}
-
-export interface RedirectsQuery {
-  redirects: {
-    redirects: Redirect[]
-    total: number
-  }
 }

--- a/react/components/Admin/Redirects/RedirectForm/utils.ts
+++ b/react/components/Admin/Redirects/RedirectForm/utils.ts
@@ -27,19 +27,28 @@ export const getStoreUpdater = (operation: 'delete' | 'save') => (
     const queryData = readRedirectsFromStore(store)
 
     if (queryData) {
-      const newRedirects = isDelete
-        ? (deleteRedirect &&
+      const newRedirects =
+        (isDelete
+          ? deleteRedirect &&
             queryData.redirects.redirects.filter(
               redirect => redirect.id !== deleteRedirect.id,
-            )) ||
-          queryData.redirects.redirects
-        : (saveRedirect &&
-            queryData.redirects.redirects.concat(saveRedirect)) ||
-          queryData.redirects.redirects
+            )
+          : saveRedirect &&
+            queryData.redirects.redirects.reduce(
+              (acc, currRedirect) =>
+                currRedirect.cacheId ===
+                `${saveRedirect.from}__${saveRedirect.to}`
+                  ? acc
+                  : [...acc, currRedirect],
+              [saveRedirect],
+            )) || queryData.redirects.redirects
 
-      const newTotal = isDelete
-        ? queryData.redirects.total - 1
-        : queryData.redirects.total + 1
+      const newTotal =
+        newRedirects.length !== queryData.redirects.redirects.length
+          ? isDelete
+            ? queryData.redirects.total - 1
+            : queryData.redirects.total + 1
+          : queryData.redirects.total
 
       const newData = {
         ...queryData,

--- a/react/components/Admin/Redirects/RedirectForm/utils.ts
+++ b/react/components/Admin/Redirects/RedirectForm/utils.ts
@@ -2,8 +2,9 @@ import { DataProxy } from 'apollo-cache'
 
 import Redirects from '../../../../queries/Redirects.graphql'
 import { PAGINATION_START, PAGINATION_STEP } from '../consts'
+import { RedirectsQuery } from '../typings'
 
-import { MutationResult, QueryData, RedirectsQuery } from './typings'
+import { MutationResult, QueryData } from './typings'
 
 const cacheAccessParameters = {
   query: Redirects,

--- a/react/components/Admin/Redirects/RedirectList/typings.d.ts
+++ b/react/components/Admin/Redirects/RedirectList/typings.d.ts
@@ -1,0 +1,15 @@
+import { RedirectsQuery } from '../typings'
+
+export interface FetchMoreOptions {
+  updateQuery: (prevData: RedirectsQuery, newData: UpdateQueryNewData) => void
+  variables: QueryVariables
+}
+
+interface QueryVariables {
+  from: number
+  to: number
+}
+
+interface UpdateQueryNewData {
+  fetchMoreResult?: RedirectsQuery
+}

--- a/react/components/Admin/Redirects/typings.d.ts
+++ b/react/components/Admin/Redirects/typings.d.ts
@@ -1,0 +1,6 @@
+export interface RedirectsQuery {
+  redirects: {
+    redirects: Redirect[]
+    total: number
+  }
+}

--- a/react/locales/en.json
+++ b/react/locales/en.json
@@ -32,7 +32,7 @@
   "pages.editor.info.title": "Page Info",
   "pages.admin.loading": "Loading",
   "pages.admin.redirects.button.create": "New redirect",
-  "pages.admin.redirects.emptyState": "No redirects created",
+  "pages.admin.redirects.emptyState": "No redirects created.",
   "pages.admin.redirects.form.button.back": "Back",
   "pages.admin.redirects.form.button.cancel": "Cancel",
   "pages.admin.redirects.form.button.create": "Create",

--- a/react/locales/es.json
+++ b/react/locales/es.json
@@ -23,7 +23,7 @@
   "pages.editor.info.title": "Informaciones de la Página",
   "pages.admin.loading": "Cargando",
   "pages.admin.redirects.button.create": "Nueva redirección",
-  "pages.admin.redirects.emptyState": "Ninguna redirección creada",
+  "pages.admin.redirects.emptyState": "Ninguna redirección creada.",
   "pages.admin.redirects.form.button.back": "Volver",
   "pages.admin.redirects.form.button.cancel": "Cancelar",
   "pages.admin.redirects.form.button.create": "Crear",

--- a/react/locales/pt.json
+++ b/react/locales/pt.json
@@ -24,7 +24,7 @@
   "pages.editor.info.title": "Informações da Página",
   "pages.admin.loading": "Carregando",
   "pages.admin.redirects.button.create": "Novo redirecionamento",
-  "pages.admin.redirects.emptyState": "Nenhum redirecionamento criado",
+  "pages.admin.redirects.emptyState": "Nenhum redirecionamento criado.",
   "pages.admin.redirects.form.button.back": "Voltar",
   "pages.admin.redirects.form.button.cancel": "Cancelar",
   "pages.admin.redirects.form.button.create": "Criar",


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Fix Apollo cache/fetch logic;
- Remove loading from remove button outside of modal;
- Add periods to empty state i18n texts;
- Remove some `console.log`s.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Post-mutation cache issues.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/admin/cms/redirects.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)