### PR TITLE
Fix - EditorContainer responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.8] - 2018-10-24
 ### Fixed
 - **`EditorContainer`**
   - Non-responsive behavior when admin sidebar gets expanded/collapsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`EditorContainer`**
+  - Non-responsive behavior when admin sidebar gets expanded/collapsed.
 
 ## [2.2.7] - 2018-10-24
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/EditorContainer.tsx
+++ b/react/components/EditorContainer.tsx
@@ -145,17 +145,10 @@ export default class EditorContainer extends Component<
   }
 
   public renderSideBar() {
-    const { visible } = this.props
-
     return (
       <div
         id="sidebar-vtex-editor"
         className="right-0-ns z-1 h-100 top-3em-ns calc--height-ns w-18em-ns fixed w-100 w-auto-ns"
-        style={{
-          animationDuration: '0.333s',
-          transform: `translate(${visible ? '0%' : '+100%'}, 0)`,
-          transition: `transform 300ms ease-in-out ${visible ? '300ms' : ''}`,
-        }}
       >
         <nav
           id="admin-sidebar"
@@ -176,38 +169,31 @@ export default class EditorContainer extends Component<
       toggleShowAdminControls,
       viewports,
       visible,
-      runtime,
     } = this.props
 
     return (
       <div className="w-100 flex flex-column flex-row-l flex-wrap-l bg-white bb bw1 b--light-silver">
-        {this.renderSideBar()}
-        <div className="calc--height calc--height-ns calc--width-ns calc--width-m calc--width-l">
-          <div className="ph5 f5 near-black h-3em h-3em-ns w-100 bb bw1 flex justify-between items-center b--light-silver shadow-solid-y">
-            <div className="flex items-center">
-              <h3 className="f5 pr3">
-                <FormattedMessage id="pages.editor.editpath.label" />:
-              </h3>
-              {iframeWindow.location.pathname}
+        {visible && this.renderSideBar()}
+        <div
+          className={`calc--height calc--height-ns ${
+            visible ? 'calc--width' : 'w-100'
+          }`}
+        >
+          {visible && (
+            <div className="ph5 f5 near-black h-3em h-3em-ns w-100 bb bw1 flex justify-between items-center b--light-silver shadow-solid-y">
+              <div className="flex items-center">
+                <h3 className="f5 pr3">
+                  <FormattedMessage id="pages.editor.editpath.label" />:
+                </h3>
+                {iframeWindow.location.pathname}
+              </div>
             </div>
-          </div>
+          )}
           <div
             id={APP_CONTENT_ELEMENT_ID}
-            className={`pa5 flex items-center bg-light-silver z-0 center-m left-0-m absolute-m overflow-x-auto-m ${
-              visible
-                ? `${
-                    runtime ? 'calc--height-relative' : 'calc--height'
-                  } calc--width-ns calc--width-m calc--width-l`
-                : 'top-0 w-100 h-100'
+            className={`pa5 flex items-center bg-light-silver z-0 center-m left-0-m relative overflow-x-auto-m ${
+              visible ? 'calc--height-relative' : 'top-0 w-100 h-100'
             }`}
-            style={{
-              top: `${visible && runtime ? 3 : 0}em`,
-              transition: `width 300ms ease-in-out ${
-                visible ? '300ms' : ''
-              }, top 300ms ease-in-out ${
-                visible ? '' : '300ms'
-              }, height 300ms ease-in-out ${visible ? '' : '300ms'}`,
-            }}
           >
             <Draggable
               bounds="parent"

--- a/react/components/EditorContainer.tsx
+++ b/react/components/EditorContainer.tsx
@@ -76,15 +76,21 @@ export default class EditorContainer extends Component<
     window.postMessage({ action: { type: 'STOP_LOADING' } }, '*')
   }
 
-  public getSnapshotBeforeUpdate(prevProps: Props & RenderContextProps & EditorContextProps) {
-    const { editor: { editMode } } = this.props
+  public getSnapshotBeforeUpdate(
+    prevProps: Props & RenderContextProps & EditorContextProps,
+  ) {
+    const {
+      editor: { editMode },
+    } = this.props
     if (prevProps.editor.editMode !== editMode) {
       this.highlightExtensionPoint(null)
     }
   }
 
   public highlightExtensionPoint = (highlightTreePath: string | null) => {
-    const { editor: { editMode, editExtensionPoint } } = this.props
+    const {
+      editor: { editMode, editExtensionPoint },
+    } = this.props
 
     this.setState({ highlightTreePath }, () => {
       const iframe = document.getElementById('store-iframe')
@@ -93,7 +99,7 @@ export default class EditorContainer extends Component<
           editExtensionPoint,
           editMode,
           highlightExtensionPoint: this.highlightExtensionPoint,
-          highlightTreePath
+          highlightTreePath,
         })
       }
     })
@@ -106,33 +112,35 @@ export default class EditorContainer extends Component<
       runtime,
     } = this.props
 
-    return (
-      runtime
-      ? editTreePath === null ? (
-          <Fragment>
-            <div className="flex justify-between items-center">
-              <h3 className="near-black f5 mv0 pa5">
-                <FormattedMessage id="pages.editor.components.title" />
-              </h3>
-              <div
-                onClick={toggleEditMode}
-                className="bg-white bn link pl3 pv3 dn flex-ns items-center justify-center self-right z-max pointer animated fadeIn"
-              >
-                <span className="pr5 b--light-gray flex items-center"><SelectionIcon stroke={editMode ? '#368df7' : '#979899'} /></span>
-              </div>
+    return runtime ? (
+      editTreePath === null ? (
+        <Fragment>
+          <div className="flex justify-between items-center">
+            <h3 className="near-black f5 mv0 pa5">
+              <FormattedMessage id="pages.editor.components.title" />
+            </h3>
+            <div
+              onClick={toggleEditMode}
+              className="bg-white bn link pl3 pv3 dn flex-ns items-center justify-center self-right z-max pointer animated fadeIn"
+            >
+              <span className="pr5 b--light-gray flex items-center">
+                <SelectionIcon stroke={editMode ? '#368df7' : '#979899'} />
+              </span>
             </div>
-            <ComponentsList
-              editor={editor}
-              runtime={runtime}
-              highlightExtensionPoint={this.highlightExtensionPoint}
-            />
-          </Fragment>
-        ) : (
-          <ComponentEditor editor={editor} runtime={runtime} />
-        )
-      : <div className="mt5 flex justify-center">
-          <Spinner />
-        </div>
+          </div>
+          <ComponentsList
+            editor={editor}
+            runtime={runtime}
+            highlightExtensionPoint={this.highlightExtensionPoint}
+          />
+        </Fragment>
+      ) : (
+        <ComponentEditor editor={editor} runtime={runtime} />
+      )
+    ) : (
+      <div className="mt5 flex justify-center">
+        <Spinner />
+      </div>
     )
   }
 
@@ -177,7 +185,9 @@ export default class EditorContainer extends Component<
         <div className="calc--height calc--height-ns calc--width-ns calc--width-m calc--width-l">
           <div className="ph5 f5 near-black h-3em h-3em-ns w-100 bb bw1 flex justify-between items-center b--light-silver shadow-solid-y">
             <div className="flex items-center">
-              <h3 className="f5 pr3"><FormattedMessage id="pages.editor.editpath.label" />:</h3>
+              <h3 className="f5 pr3">
+                <FormattedMessage id="pages.editor.editpath.label" />:
+              </h3>
               {iframeWindow.location.pathname}
             </div>
           </div>
@@ -185,7 +195,9 @@ export default class EditorContainer extends Component<
             id={APP_CONTENT_ELEMENT_ID}
             className={`pa5 flex items-center bg-light-silver z-0 center-m left-0-m absolute-m overflow-x-auto-m ${
               visible
-                ? `${runtime ? 'calc--height-relative' : 'calc--height'} calc--width-ns calc--width-m calc--width-l`
+                ? `${
+                    runtime ? 'calc--height-relative' : 'calc--height'
+                  } calc--width-ns calc--width-m calc--width-l`
                 : 'top-0 w-100 h-100'
             }`}
             style={{
@@ -194,9 +206,7 @@ export default class EditorContainer extends Component<
                 visible ? '300ms' : ''
               }, top 300ms ease-in-out ${
                 visible ? '' : '300ms'
-              }, height 300ms ease-in-out ${
-                visible ? '' : '300ms'
-              }`,
+              }, height 300ms ease-in-out ${visible ? '' : '300ms'}`,
             }}
           >
             <Draggable
@@ -215,14 +225,19 @@ export default class EditorContainer extends Component<
               }}
             >
               <div className="animated br2 bg-white bn shadow-1 flex items-center justify-center z-max absolute bottom-1 bottom-2-ns left-1 left-2-ns">
-                <DeviceSwitcher toggleEditMode={toggleShowAdminControls} editor={editor} viewports={viewports} inPreview={!visible}/>
+                <DeviceSwitcher
+                  toggleEditMode={toggleShowAdminControls}
+                  editor={editor}
+                  viewports={viewports}
+                  inPreview={!visible}
+                />
               </div>
             </Draggable>
             <main
               {...getContainerProps(viewport)}
               role="main"
               style={{
-                transition: `width 300ms ease-in-out 0ms, height 300ms ease-in-out 0ms`
+                transition: `width 300ms ease-in-out 0ms, height 300ms ease-in-out 0ms`,
               }}
             >
               {this.props.children}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Replace a few `EditorContainer` styles — mainly `calc--width`s;
- Remove some animations (for now);
- Format previous code.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Non-responsive behavior when admin sidebar gets expanded/collapsed.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/admin/cms/storefront.

#### Screenshots or example usage
##### Before
![image](https://user-images.githubusercontent.com/8486092/45826093-182fc680-bcca-11e8-863c-687b781e113d.png)

<hr />

##### After
![image](https://user-images.githubusercontent.com/8486092/45825272-3f859400-bcc8-11e8-971d-8386a1443525.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)