### PR TITLE
Feature - Ordered component list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.0] - 2018-10-24
 ### Changed
 - **`ComponentsList`**
   - Sort components by display order (top/left first).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **`ComponentsList`**
+  - Sort components by display order (top/left first).
 
 ## [2.2.9] - 2018-10-24
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.2.9",
+  "version": "2.3.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/ComponentsList.tsx
+++ b/react/components/ComponentsList.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { canUseDOM } from 'render'
 
 import { getIframeImplementation } from '../utils/components'
 
@@ -63,8 +64,23 @@ class ComponentsList extends Component<
         <div className="bb b--light-silver" />
         {Object.keys(extensions)
           .filter(this.validateExtension)
+          .sort(this.sortComponents)
           .map(this.renderComponentButton)}
       </div>
+    )
+  }
+
+  private getComponentElement = (treePath: string) => {
+    const {
+      editor: { iframeWindow },
+    } = this.props
+
+    if (!canUseDOM) {
+      return undefined
+    }
+
+    return iframeWindow.document.querySelector(
+      `[data-extension-point="${treePath}"]`,
     )
   }
 
@@ -98,6 +114,29 @@ class ComponentsList extends Component<
       </div>
     </button>
   )
+
+  private sortComponents = (treePathA: string, treePathB: string) => {
+    const componentA = this.getComponentElement(treePathA)
+
+    if (!componentA) {
+      return 1
+    }
+
+    const componentB = this.getComponentElement(treePathB)
+
+    if (!componentB) {
+      return -1
+    }
+
+    const { x: xA, y: yA } = componentA.getBoundingClientRect() as DOMRect
+    const { x: xB, y: yB } = componentB.getBoundingClientRect() as DOMRect
+
+    if (yA > yB || (yA === yB && xA > xB)) {
+      return 1
+    }
+
+    return -1
+  }
 
   private validateExtension = (treePath: string) => {
     const {

--- a/react/components/ComponentsList.tsx
+++ b/react/components/ComponentsList.tsx
@@ -4,6 +4,10 @@ import { FormattedMessage } from 'react-intl'
 
 import { getIframeImplementation } from '../utils/components'
 
+interface Props {
+  highlightExtensionPoint: (treePath: string | null) => void
+}
+
 const getComponentSchema = (component: string, props: any) => {
   const ComponentImpl = component && getIframeImplementation(component)
   return (
@@ -24,10 +28,6 @@ const isDifferentPage = (treePath: string, page: string, pages: string[]) => {
     (p: string) => p.split('/').length === currentPageLevel,
   )
   return !!sameLevelPages.find((p: string) => treePath.startsWith(p))
-}
-
-interface Props {
-  highlightExtensionPoint: (treePath: string | null) => void
 }
 
 class ComponentsList extends Component<
@@ -53,43 +53,6 @@ class ComponentsList extends Component<
     this.props.highlightExtensionPoint(null)
   }
 
-  public renderComponentButton = (treePath: string) => {
-    const {
-      runtime: { extensions, page, pages },
-    } = this.props
-    const { component, props = {} } = extensions[treePath]
-    const schema = getComponentSchema(component, props)
-
-    if (
-      !schema ||
-      !schema.title ||
-      isDifferentPage(treePath, page, Object.keys(pages))
-    ) {
-      return null
-    }
-
-    return (
-      <button
-        key={treePath}
-        type="button"
-        data-tree-path={treePath}
-        onClick={this.onEdit}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-        className={
-          'dark-gray bg-white pt5 pointer hover-bg-light-silver w-100 tl bn ph0 pb0'
-        }
-        style={{ animationDuration: '0.2s' }}
-      >
-        <div className="bb b--light-silver w-100 pb5">
-          <span className="f6 fw5 pl5 track-1">
-            <FormattedMessage id={schema.title} />
-          </span>
-        </div>
-      </button>
-    )
-  }
-
   public render() {
     const {
       runtime: { extensions },
@@ -98,8 +61,55 @@ class ComponentsList extends Component<
     return (
       <div>
         <div className="bb b--light-silver" />
-        {Object.keys(extensions).map(this.renderComponentButton)}
+        {Object.keys(extensions)
+          .filter(this.validateExtension)
+          .map(this.renderComponentButton)}
       </div>
+    )
+  }
+
+  private getSchema(treePath: string) {
+    const {
+      runtime: { extensions },
+    } = this.props
+
+    const { component, props = {} } = extensions[treePath]
+
+    return getComponentSchema(component, props)
+  }
+
+  private renderComponentButton = (treePath: string) => (
+    <button
+      key={treePath}
+      type="button"
+      data-tree-path={treePath}
+      onClick={this.onEdit}
+      onMouseEnter={this.handleMouseEnter}
+      onMouseLeave={this.handleMouseLeave}
+      className={
+        'dark-gray bg-white pt5 pointer hover-bg-light-silver w-100 tl bn ph0 pb0'
+      }
+      style={{ animationDuration: '0.2s' }}
+    >
+      <div className="bb b--light-silver w-100 pb5">
+        <span className="f6 fw5 pl5 track-1">
+          <FormattedMessage id={this.getSchema(treePath).title} />
+        </span>
+      </div>
+    </button>
+  )
+
+  private validateExtension = (treePath: string) => {
+    const {
+      runtime: { pages, page },
+    } = this.props
+
+    const schema = this.getSchema(treePath)
+
+    return (
+      schema &&
+      schema.title &&
+      !isDifferentPage(treePath, page, Object.keys(pages))
     )
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Sort components from `ComponentsList` by display order (top/left first).

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Unintuitive component order.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/admin/cms/storefront/.

#### Screenshots or example usage
##### Before
![image](https://user-images.githubusercontent.com/8486092/46041993-9df8ab00-c0ea-11e8-9f79-6df8d1edbb75.png)

<hr />

##### After
![image](https://user-images.githubusercontent.com/8486092/46041920-6e49a300-c0ea-11e8-8316-e9afceb01e0d.png)

#### Types of changes
- New feature (a non-breaking change which adds functionality)