### PR TITLE
Fix - Runtime custom messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.3] - 2018-11-05
 ### Added
 - **Typings**
   - `Window` interface with custom methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `Window` interface with custom methods.
 
 - **`EditorProvider`**
-  - Add `emitLocaleEventToIframe` method to sync iframe locale.
+  - `emitLocaleEventToIframe` method to sync iframe locale.
 
 ### Fixed
 - **`lint.sh`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Typings**
+  - `Window` interface with custom methods.
+- **`EditorProvider`**
+  - `emitLocaleEventToIframe` method to sync iframe locale.
+
+### Fixed
+- **`EditorProvider`**
+  - I18n messages update logic.
+  - Typing and formatting.
 
 ## [2.3.2] - 2018-11-05
 ### Added
@@ -21,12 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **`utils/components.ts`**
   - Used to be `components.js`
 
-  - **Typings**
-  - `Window` interface with custom methods.
-
-- **`EditorProvider`**
-  - `emitLocaleEventToIframe` method to sync iframe locale.
-
 ### Fixed
 - **`lint.sh`**
   - Use lint command in react folder.
@@ -36,10 +40,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Type window.
 - **`ComponentEditor/index.tsx`**
   - Several type errors.
-
-- **`EditorProvider`**
-  - I18n messages update logic.
-  - Typing and formatting.
 
 ### Changed
 - **`manifest.json`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - **Typings**
   - `Window` interface with custom methods.
 
+- **`EditorProvider`**
+  - Add `emitLocaleEventToIframe` method to sync iframe locale.
+
 ### Fixed
 - **`lint.sh`**
   - Use lint command in react folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **`utils/components.ts`**
   - Used to be `components.js`
 
+  - **Typings**
+  - `Window` interface with custom methods.
+
 ### Fixed
 - **`lint.sh`**
   - Use lint command in react folder.
@@ -30,6 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Type window.
 - **`ComponentEditor/index.tsx`**
   - Several type errors.
+
+- **`EditorProvider`**
+  - I18n messages update logic.
+  - Typing and formatting.
 
 ### Changed
 - **`manifest.json`**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/EditorProvider.tsx
+++ b/react/EditorProvider.tsx
@@ -54,14 +54,16 @@ class EditorProvider extends Component<Props, State> {
     }
 
     if (canUseDOM) {
-      window.__provideRuntime = (
+      window.__provideRuntime = async (
         runtime: RenderContext,
         messages: Record<string, string>,
       ) => {
         iframeMessages = messages
 
+        await this.props.runtime.updateRuntime()
+
         if (!this.state.iframeRuntime) {
-          runtime.updateComponentAssets(props.runtime.components)
+          runtime.updateComponentAssets(this.props.runtime.components)
           this.props.runtime.updateComponentAssets({})
         }
 

--- a/react/EditorProvider.tsx
+++ b/react/EditorProvider.tsx
@@ -70,6 +70,7 @@ class EditorProvider extends Component<Props, State> {
         }
 
         const newState = {
+          ...this.state,
           iframeRuntime: runtime,
           ...(this.state.iframeRuntime
             ? {}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -206,4 +206,11 @@ declare global {
   }
 
   type UISchema = any
+
+  interface Window extends Window {
+    __provideRuntime?: (
+      runtime: RenderContext | null,
+      messages?: Record<string, string>,
+    ) => void
+  }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -207,7 +207,7 @@ declare global {
 
   type UISchema = any
 
-  interface Window extends Window {
+  interface Window {
     __provideRuntime?: (
       runtime: RenderContext,
       messages?: Record<string, string>,

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -209,7 +209,7 @@ declare global {
 
   interface Window extends Window {
     __provideRuntime?: (
-      runtime: RenderContext | null,
+      runtime: RenderContext,
       messages?: Record<string, string>,
     ) => void
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Fix i18n messages update logic;
- Add `__getEmitter` method to `Window` (if `canUseDOM`);
- Add custom methods to `Window` interface;
- Fix `EditorProvider`'s typing and formatting, and improve its readability.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
I18n issues.

#### How should this be manually tested?
Workspace: https://fixruntimecustommessages--lojadaju.myvtex.com/admin/cms/storefront.

#### Screenshots or example usage
##### Before
<img width="319" alt="image" src="https://user-images.githubusercontent.com/8486092/46832509-9ee13c00-cd7c-11e8-8654-c1069f190731.png">

##### After
<img width="331" alt="image" src="https://user-images.githubusercontent.com/8486092/46832463-75c0ab80-cd7c-11e8-8a83-9510f6461b1c.png">

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)