### PR TITLE
Fix mobile/tablet positioning on storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.6] - 2018-10-24
 ### Fixed
 - **`editbar.global.css`**
   - Fixing tablet positioning on storefront editor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`editbar.global.css`**
+  - Fixing tablet positioning on storefront editor
 
 ## [2.2.5] - 2018-10-04
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -221,6 +221,7 @@ html, body {
 .mobile-preview {
   width: 360px;
   height: 640px;
+  max-height: 100%;
   overflow-x: hidden;
   box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.2);
 }
@@ -228,6 +229,7 @@ html, body {
 .tablet-preview {
   width: 768px;
   height: 1024px;
+  max-height: 100%;
   overflow-x: hidden;
   box-shadow: 1px 4px 8px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
It fixes a small bug caused by tablet positioning on storefront.

#### What problem is this solving?
When the page height was too low to fit the device, the parts exceding the height were hidden. Now, I'm limiting the height of the device so that it can always be shown fully.


#### How should this be manually tested?
Workspace with change applied: https://adminpages93--storecomponents.myvtex.com/admin/cms/storefront
Access the storefront editor and switch to a device display that doesn't fit your browser window.

#### Screenshots or example usage
Before:
<img width="1437" alt="screen shot 2018-10-15 at 10 58 49" src="https://user-images.githubusercontent.com/3386440/46957366-caf70880-d06d-11e8-9d96-b99ecb691ca3.png">

After:
<img width="1401" alt="screen shot 2018-10-15 at 11 31 08" src="https://user-images.githubusercontent.com/3386440/46957385-d5190700-d06d-11e8-9708-3ad17ef65558.png">

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
