### PR TITLE
Fix - Missing calc--width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`editbar.global.css`**
+  - Missing `calc--width` class.
 
 ## [2.3.0] - 2018-10-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.1] - 2018-10-29
 ### Added
 - **`editbar.global.css`**
   - Missing `calc--width` class.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -146,6 +146,10 @@ html, body {
   width: 100%;
 }
 
+.calc--width {
+  width: calc(100% - 18em);
+}
+
 @media only screen and (max-width: 40em) {
   .size-editor {
     bottom: 0;


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add `calc--width` CSS class.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Missing CSS class declaration (used [here](https://github.com/vtex-apps/admin-pages/blob/5fd0028829759f28b1f6448dbb2b25508bbcb0f8/react/components/EditorContainer.tsx#L179)).

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)