### PR TITLE
Disable SSR for HighlightOverlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **`pages.json`**
+  - Set HighlightOverlay `ssr` as `false`.
+
+### Fixed
+- **`HighlightOverlay`**
+  - Checking if `setHighlightTreePath` is defined before calling it.
 
 ## [2.3.3] - 2018-11-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.4] - 2018-11-06
 ### Changed
 - **`pages.json`**
   - Set HighlightOverlay `ssr` as `false`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -27,7 +27,8 @@
   },
   "extensions": {
     "store/__overlay": {
-      "component": "HighlightOverlay"
+      "component": "HighlightOverlay",
+      "ssr": false
     },
     "admin/cms/__provider": {
       "component": "EditorProvider"

--- a/react/components/EditorContainer.tsx
+++ b/react/components/EditorContainer.tsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types'
+import { path } from 'ramda'
 import React, { Component, Fragment } from 'react'
 import Draggable from 'react-draggable'
 import { FormattedMessage } from 'react-intl'
 import { Spinner } from 'vtex.styleguide'
 
+import { State as HighlightOverlayState } from '../HighlightOverlay'
 import SelectionIcon from '../images/SelectionIcon.js'
 import ComponentEditor from './ComponentEditor'
 import ComponentsList from './ComponentsList'
@@ -93,9 +95,11 @@ export default class EditorContainer extends Component<
     } = this.props
 
     this.setState({ highlightTreePath }, () => {
-      const iframe = document.getElementById('store-iframe') as HighlightableIFrame | null
-      if (iframe && iframe.contentWindow) {
-        iframe.contentWindow.__setHighlightTreePath({
+
+      const iframe = document.getElementById('store-iframe') || {} as HighlightableIFrame
+      const setHighlightTreePath = path<(value: HighlightOverlayState) => void>(['contentWindow', '__setHighlightTreePath'], iframe)
+      if (setHighlightTreePath) {
+        setHighlightTreePath({
           editExtensionPoint,
           editMode,
           highlightExtensionPoint: this.highlightExtensionPoint,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR disable `ssr` for the `HighlightOverlay` extension.

#### What problem is this solving?
Server side rendering was pushing unwanted CSS to production apps.

#### How should this be manually tested?
- [x] Link `pages-graphql@fix/include-underscore-extensions` and check for the CSS on any `store/home`.
- [x] Storefront should be working as usual (**important**: `pages-graphql` must be in the correct branch).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
