### PR TITLE
Fix components messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.5] - 2018-11-07
 ### Added
 - **`MessagesContext`**
   - Create context to pass iframe locale messages to `PageEditor`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`MessagesContext`**
+  - Create context to pass iframe locale messages to `PageEditor`.
+- **`EditorProvider`**
+  - New component to wrap `EditorProvider` with `MessagesContext.Consumer`.
+- **`PageEditor`**
+  - static method `getCustomMessages`
+  - `Message.Provider`
 
 ## [2.3.4] - 2018-11-06
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -1,13 +1,16 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
+import MessagesContext, { IMessagesContext } from './components/MessagesContext'
 import EditorProvider from './EditorProvider'
 
 interface PageEditorProps {
   params: any
 }
 
-class PageEditor extends Component<PageEditorProps> {
+let messages = {}
+
+class PageEditor extends Component<PageEditorProps, IMessagesContext> {
   public static propTypes = {
     children: PropTypes.element,
     data: PropTypes.object,
@@ -17,6 +20,21 @@ class PageEditor extends Component<PageEditorProps> {
     prefetchPage: PropTypes.func,
     startLoading: PropTypes.func,
     stopLoading: PropTypes.func,
+  }
+
+  public static getCustomMessages = () => {
+    return messages
+  }
+
+  constructor(props: PageEditorProps) {
+    super(props)
+    this.state = {
+      setMessages: this.setMessages
+    }
+  }
+
+  public setMessages = (newMessages?: object) => {
+    messages = newMessages || {}
   }
 
   public componentDidMount() {
@@ -35,14 +53,16 @@ class PageEditor extends Component<PageEditorProps> {
     const { params: { path } } = this.props
 
     return (
-      <EditorProvider>
-        <iframe
-          id="store-iframe"
-          className="w-100 h-100"
-          src={['/', path].filter((str) => !!str).join('')}
-          frameBorder="0"
-        />
-      </EditorProvider>
+      <MessagesContext.Provider value={this.state}>
+        <EditorProvider>
+          <iframe
+            id="store-iframe"
+            className="w-100 h-100"
+            src={['/', path].filter((str) => !!str).join('')}
+            frameBorder="0"
+          />
+        </EditorProvider>
+      </MessagesContext.Provider>
     )
   }
 }

--- a/react/components/MessagesContext.tsx
+++ b/react/components/MessagesContext.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export interface IMessagesContext {
+  setMessages: (newMessages?: object) => void
+}
+
+// tslint:disable-next-line:no-empty
+const MessagesContext: React.Context<IMessagesContext> = React.createContext({setMessages: () => {}})
+
+export default MessagesContext


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add MessagesContext and passing iframeMessages to `PageEditor` file.

#### What problem is this solving?
It fixes component titles on storefront.

#### How should this be manually tested?
Workspace: https://fixcomponentnames--storecomponents.myvtex.com/

1. Enter on [admin home](https://fixcomponentnames--storecomponents.myvtex.com/admin) 
2. Navigate to Storefront

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
