### PR TITLE
Fix ScopeSelector behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`ComponentEditor`**
+  - `handleScopeChange` method signature updated.
 
 ## [2.3.8] - 2018-11-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.9] - 2018-11-26
 ### Fixed
 - **`ComponentEditor`**
   - `handleScopeChange` method signature updated.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -710,7 +710,7 @@ class ComponentEditor extends Component<
     editor.editExtensionPoint(null)
   }
 
-  private handleScopeChange = (newScope: ConfigurationScope) => {
+  private handleScopeChange = (e: React.ChangeEvent<HTMLSelectElement>, newScope: ConfigurationScope) => {
     if (
       this.state.configuration &&
       newScope !== this.state.configuration.scope

--- a/react/components/ConditionsSelector/ScopeSelector.tsx
+++ b/react/components/ConditionsSelector/ScopeSelector.tsx
@@ -18,16 +18,27 @@ const SCOPE_CONDITIONS = [
   },
 ]
 
-const getOptions = ({intl, shouldEnableSite}: {intl: InjectedIntl, shouldEnableSite: boolean}) => {
-  const conditions = shouldEnableSite ? [...SCOPE_CONDITIONS, SITE_SCOPE_CONDITION] : SCOPE_CONDITIONS
+const getOptions = ({
+  intl,
+  shouldEnableSite,
+}: {
+  intl: InjectedIntl
+  shouldEnableSite: boolean
+}) => {
+  const conditions = shouldEnableSite
+    ? [...SCOPE_CONDITIONS, SITE_SCOPE_CONDITION]
+    : SCOPE_CONDITIONS
   return conditions.map(option => ({
     ...option,
-    label: option.label && intl.formatMessage({id: option.label}),
+    label: option.label && intl.formatMessage({ id: option.label }),
   }))
 }
 
 interface Props {
-  onChange: (e: React.ChangeEvent<HTMLSelectElement>, value: ConfigurationScope) => void
+  onChange: (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    value: ConfigurationScope,
+  ) => void
   shouldEnableSite: boolean
   value: ConfigurationScope
 }
@@ -43,7 +54,7 @@ const ScopeSelector = ({
       id: 'pages.editor.components.conditions.native.label',
     })}
     onChange={onChange}
-    options={getOptions({intl, shouldEnableSite})}
+    options={getOptions({ intl, shouldEnableSite })}
     value={value}
   />
 )

--- a/react/components/ConditionsSelector/ScopeSelector.tsx
+++ b/react/components/ConditionsSelector/ScopeSelector.tsx
@@ -27,7 +27,7 @@ const getOptions = ({intl, shouldEnableSite}: {intl: InjectedIntl, shouldEnableS
 }
 
 interface Props {
-  onChange: (value: ConfigurationScope) => void
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>, value: ConfigurationScope) => void
   shouldEnableSite: boolean
   value: ConfigurationScope
 }

--- a/react/components/ConditionsSelector/index.tsx
+++ b/react/components/ConditionsSelector/index.tsx
@@ -5,7 +5,7 @@ import ScopeSelector from './ScopeSelector'
 
 interface Props {
   onCustomConditionsChange: (newConditionsIds: string[]) => void
-  onScopeChange: (newScope: ConfigurationScope) => void
+  onScopeChange: (e: React.ChangeEvent<HTMLSelectElement>, newScope: ConfigurationScope) => void
   scope?: ConfigurationScope
   selectedConditions: string[]
 }
@@ -27,7 +27,13 @@ const ConditionsSelector = ({
     (editTreePath && !editTreePath.startsWith(page)) || false
 
   if (!shouldEnableSite && scope === 'site') {
-    onScopeChange('route')
+    // Only the second argument is used
+    const mockEvent = {
+      target: {
+        value: 'route'
+      }
+    }
+    onScopeChange(mockEvent as React.ChangeEvent<HTMLSelectElement>, 'route')
   }
 
   const shouldEnableCustomConditions = scope !== 'site'

--- a/react/components/ConditionsSelector/index.tsx
+++ b/react/components/ConditionsSelector/index.tsx
@@ -5,7 +5,10 @@ import ScopeSelector from './ScopeSelector'
 
 interface Props {
   onCustomConditionsChange: (newConditionsIds: string[]) => void
-  onScopeChange: (e: React.ChangeEvent<HTMLSelectElement>, newScope: ConfigurationScope) => void
+  onScopeChange: (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    newScope: ConfigurationScope,
+  ) => void
   scope?: ConfigurationScope
   selectedConditions: string[]
 }
@@ -30,8 +33,8 @@ const ConditionsSelector = ({
     // Only the second argument is used
     const mockEvent = {
       target: {
-        value: 'route'
-      }
+        value: 'route',
+      },
     }
     onScopeChange(mockEvent as React.ChangeEvent<HTMLSelectElement>, 'route')
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
ScopeSelector Dropdown was replaced by Styleguide's Dropdown component but the API wasn't updated. This PR updates the change handler.

#### What problem is this solving?
Fix Scope Selector behaviour so user can select scope.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
