### PR TITLE
Feature - Move menu links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Pages**
+  - Rename "page list" to "pages".
+
+- **`pages.json`**
+  - Move admin links to CMS section.
 
 ## [2.4.0] - 2018-12-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.0] - 2018-12-05
 ### Changed
 - **Pages**
   - Rename "page list" to "pages".

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -68,7 +68,7 @@
           },
           {
             "isNew": true,
-            "labelId": "pages.admin-menu-button.pageList",
+            "labelId": "pages.admin-menu-button.pages",
             "path": "/admin/cms/pages"
           },
           {

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -57,27 +57,27 @@
     "admin/cms/settings": {
       "component": "Settings"
     },
-    "admin/navigation/storeSetup/pages": {
+    "admin/navigation/storeSetup/cms": {
       "component": "vtex.admin/InjectNavigationData",
       "props": {
-        "icon": "extensions-ic",
-        "id": "38",
         "subItems": [
           {
-            "labelId": "pages.admin-menu-button.pageList",
-            "path": "/admin/cms/pages"
-          },
-          {
+            "isNew": true,
             "labelId": "pages.admin-menu-button.storefront",
             "path": "/admin/cms/storefront"
           },
           {
+            "isNew": true,
+            "labelId": "pages.admin-menu-button.pageList",
+            "path": "/admin/cms/pages"
+          },
+          {
+            "isNew": true,
             "labelId": "pages.admin-menu-button.displayConditions",
             "path": "/admin/conditions-builder/pages"
           }
         ],
-        "tag": "appframe.new",
-        "titleId": "pages.admin-menu-button.main"
+        "titleId": "appframe.navigation.cms.title"
       }
     }
   }

--- a/react/locales/en.json
+++ b/react/locales/en.json
@@ -1,7 +1,6 @@
 {
   "pages.admin-menu-button.displayConditions": "Display conditions",
-  "pages.admin-menu-button.main": "Pages",
-  "pages.admin-menu-button.pageList": "Page list",
+  "pages.admin-menu-button.pages": "Pages",
   "pages.admin-menu-button.storefront": "Storefront",
   "pages.conditions.device.any": "Any",
   "pages.conditions.device.desktop": "Desktop",

--- a/react/locales/es.json
+++ b/react/locales/es.json
@@ -1,7 +1,6 @@
 {
   "pages.admin-menu-button.displayConditions": "Condiciones de exhibición",
-  "pages.admin-menu-button.main": "Páginas",
-  "pages.admin-menu-button.pageList": "Lista de páginas",
+  "pages.admin-menu-button.pages": "Páginas",
   "pages.admin-menu-button.storefront": "Storefront",
   "pages.conditions.scope.route": "Esta ruta",
   "pages.conditions.scope.site": "Todo el sitio",

--- a/react/locales/pt.json
+++ b/react/locales/pt.json
@@ -1,7 +1,6 @@
 {
   "pages.admin-menu-button.displayConditions": "Condições de exibição",
-  "pages.admin-menu-button.main": "Páginas",
-  "pages.admin-menu-button.pageList": "Lista de páginas",
+  "pages.admin-menu-button.pages": "Páginas",
   "pages.admin-menu-button.storefront": "Storefront",
   "pages.conditions.scope.route": "Esta rota",
   "pages.conditions.scope.site": "Todo o site",


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Move admin links to CMS section;
- Rename "page list" to "pages".

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The Pages' links should be under the CMS section.

#### How should this be manually tested?
Workspace: https://featuremovemenulinks--storecomponents.myvtex.com/admin.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8486092/49551408-45a60c80-f8d6-11e8-83b8-fbfb73015384.png)

#### Types of changes
- Redesign (non-breaking change that improves current functionality)