### PR TITLE
Fix component editor not getting default props

### DIFF
--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -290,6 +290,7 @@ class ComponentEditor extends Component<
     const extensionConfigurationsQuery = this.props.extensionConfigurations
 
     const { component, props } = this.getExtension()
+
     const componentImplementation = getIframeImplementation(component)
 
     const selectedComponent = component || null
@@ -530,7 +531,13 @@ class ComponentEditor extends Component<
       !currConfiguration ||
       currConfiguration.configurationId !== configuration.configurationId
     ) {
-      this.handleConfigurationChange(configuration)
+      const { props: extensionProps } = this.getExtension()
+      const propsJSON = configuration.propsJSON === '{}' && extensionProps ? JSON.stringify(extensionProps) : configuration.propsJSON
+
+      this.handleConfigurationChange({
+        ...configuration,
+        propsJSON
+      })
     }
 
     this.setState({ isEditMode: true })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Consider extension props when selecting a new component to edit.

#### What problem is this solving?
If you navigate to the `store/product` route and click to edit the `Footer`, it shows a empty

#### How should this be manually tested?
Workspace: https://fixfooterprops--storecomponents.myvtex.com/admin/cms/storefront.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)

#### This is a hotfix. We should think if this is the best solution.