### PR TITLE
Feature/image uploader

### DIFF
--- a/react/components/ComponentEditor/index.tsx
+++ b/react/components/ComponentEditor/index.tsx
@@ -30,6 +30,32 @@ const defaultUiSchema = {
 
 const MODES: ComponentEditorMode[] = ['content', 'layout']
 
+const nativeMap: Record<string, ComponentSchema> = {
+  nativeImage: {
+    type: 'string',
+    widget: {
+      'ui:widget': 'image-uploader',
+    },
+  },
+  nativeOptions: {
+    type: 'number',
+    widget: {
+      'ui:options': {
+        inline: true,
+      },
+      'ui:widget': 'radio',
+    },
+  }
+}
+
+const translateFromNative = (schema: ComponentSchema): ComponentSchema => {
+  const modifications = schema.type && nativeMap[schema.type]
+  if (modifications) {
+    return merge(schema,modifications)
+  }
+  return schema
+}
+
 interface ExtensionConfigurationsQuery {
   error: object
   extensionConfigurations: ExtensionConfiguration[]
@@ -156,7 +182,7 @@ class ComponentEditor extends Component<
           Array.isArray(value) ? map(translate, value) : translate(value),
         pick(['title', 'description', 'enumNames'], schema) as object
       )
-
+      translateFromNative(schema)
       if (has('widget', schema)) {
         translatedSchema.widget = merge(
           schema.widget,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create native content types (by encapsulating *types and widgets*) 

#### What problem is this solving?
We want to force the store developer to use only the native types we allow, in order to have more control about how the components are written. One of the reasons for this could be avoid bad coding, for example. 

#### How should this be manually tested?
You can simply open one of the components code in a given store (e.g. Carousel in Dreamstore), and use 
  
type: "nativeImage"    

instead of   

type:"string",widget.ui
widget: {
      'ui:widget': 'image-uploader',
}

Similarly, you can test this feature modifying any other store.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.