### PR TITLE
New get components logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Pages**
   - Rename "page list" to "pages".
 
+- **ComponentsList**
+  - Moved `getComponents` logic into another file.
+  - `getComponents` sort logic doesn't use `getBoundingClientRect` anymore. Instead, it tries to use `props.elements` from extension.
+
 - **`pages.json`**
   - Move admin links to CMS section.
 

--- a/react/components/ComponentsList/getComponents.test.ts
+++ b/react/components/ComponentsList/getComponents.test.ts
@@ -54,7 +54,7 @@ const mockComponents = {
 const mockPages = ['store/home', 'store/account', 'store/search']
 
 describe('getComponents', () => {
-  it('should return array of filtered by presence of schema and title components', () => {
+  it('should filter out components without either a schema or a title', () => {
     expect(
       getComponents(
         mockExtensions,

--- a/react/components/ComponentsList/getComponents.test.ts
+++ b/react/components/ComponentsList/getComponents.test.ts
@@ -46,21 +46,23 @@ const mockComponents = {
   },
   'vtex.shelf-title': {
     schema: {
-      title: 'Shelf Title'
-    }
-  }
+      title: 'Shelf Title',
+    },
+  },
 }
 
-const mockPages = [
-  'store/home',
-  'store/account',
-  'store/search'
-]
+const mockPages = ['store/home', 'store/account', 'store/search']
 
 describe('getComponents', () => {
-
   it('should return array of filtered by presence of schema and title components', () => {
-    expect(getComponents(mockExtensions, mockComponents as any, 'store/home', mockPages)).toEqual([
+    expect(
+      getComponents(
+        mockExtensions,
+        mockComponents as any,
+        'store/home',
+        mockPages,
+      ),
+    ).toEqual([
       {
         name: 'Carousel',
         treePath: 'store/home/carousel',
@@ -82,17 +84,20 @@ describe('getComponents', () => {
 
   it('should use elements from props of LayoutContainer to determine order', () => {
     expect(
-      getComponents({
-        ...mockExtensions,
-        'store/home': {
-          component: 'vtex.LayoutContainer',
-          props: {
-            elements: ['shelf', 'carousel'],
+      getComponents(
+        {
+          ...mockExtensions,
+          'store/home': {
+            component: 'vtex.LayoutContainer',
+            props: {
+              elements: ['shelf', 'carousel'],
+            },
           },
         },
-      }, mockComponents as any,
-      'store/home',
-      mockPages),
+        mockComponents as any,
+        'store/home',
+        mockPages,
+      ),
     ).toEqual([
       {
         name: 'Shelf',
@@ -126,10 +131,15 @@ describe('getComponents', () => {
         }),
       },
     }
-    expect(getComponents(extensions, components as any, 'store/home', ['store/home'])).toEqual([{
-      name: 'Shelf',
-      treePath: 'store/home/shelf',
-    },])
+    expect(
+      getComponents(extensions, components as any, 'store/home', [
+        'store/home',
+      ]),
+    ).toEqual([
+      {
+        name: 'Shelf',
+        treePath: 'store/home/shelf',
+      },
+    ])
   })
-
 })

--- a/react/components/ComponentsList/getComponents.test.ts
+++ b/react/components/ComponentsList/getComponents.test.ts
@@ -1,0 +1,135 @@
+import { getComponents } from './getComponents'
+
+const mockExtensions = {
+  'store/header': {
+    component: 'vtex.LayoutContainer',
+  },
+  'store/home': {
+    component: 'vtex.LayoutContainer',
+    props: {
+      elements: ['carousel', 'shelf'],
+    },
+  },
+  'store/home/carousel': {
+    component: 'vtex.carousel',
+  },
+  'store/home/no-schema': {
+    component: 'vtex.no-schema',
+  },
+  'store/home/shelf': {
+    component: 'vtex.shelf',
+  },
+  'store/home/shelf/arrow': {
+    component: 'vtex.shelf-arrow',
+  },
+  'store/home/shelf/title': {
+    component: 'vtex.shelf-title',
+  },
+}
+
+const mockComponents = {
+  'vtex.carousel': {
+    schema: {
+      title: 'Carousel',
+    },
+  },
+  'vtex.no-schema': {},
+  'vtex.shelf': {
+    schema: {
+      title: 'Shelf',
+    },
+  },
+  'vtex.shelf-arrow': {
+    schema: {
+      title: 'Arrow',
+    },
+  },
+  'vtex.shelf-title': {
+    schema: {
+      title: 'Shelf Title'
+    }
+  }
+}
+
+const mockPages = [
+  'store/home',
+  'store/account',
+  'store/search'
+]
+
+describe('getComponents', () => {
+
+  it('should return array of filtered by presence of schema and title components', () => {
+    expect(getComponents(mockExtensions, mockComponents as any, 'store/home', mockPages)).toEqual([
+      {
+        name: 'Carousel',
+        treePath: 'store/home/carousel',
+      },
+      {
+        name: 'Shelf',
+        treePath: 'store/home/shelf',
+      },
+      {
+        name: 'Arrow',
+        treePath: 'store/home/shelf/arrow',
+      },
+      {
+        name: 'Shelf Title',
+        treePath: 'store/home/shelf/title',
+      },
+    ])
+  })
+
+  it('should use elements from props of LayoutContainer to determine order', () => {
+    expect(
+      getComponents({
+        ...mockExtensions,
+        'store/home': {
+          component: 'vtex.LayoutContainer',
+          props: {
+            elements: ['shelf', 'carousel'],
+          },
+        },
+      }, mockComponents as any,
+      'store/home',
+      mockPages),
+    ).toEqual([
+      {
+        name: 'Shelf',
+        treePath: 'store/home/shelf',
+      },
+      {
+        name: 'Carousel',
+        treePath: 'store/home/carousel',
+      },
+      {
+        name: 'Arrow',
+        treePath: 'store/home/shelf/arrow',
+      },
+      {
+        name: 'Shelf Title',
+        treePath: 'store/home/shelf/title',
+      },
+    ])
+  })
+
+  it('should get components with getSchema instead of schema', () => {
+    const extensions = {
+      'store/home/shelf': {
+        component: 'vtex.shelf',
+      },
+    }
+    const components = {
+      'vtex.shelf': {
+        getSchema: () => ({
+          title: 'Shelf',
+        }),
+      },
+    }
+    expect(getComponents(extensions, components as any, 'store/home', ['store/home'])).toEqual([{
+      name: 'Shelf',
+      treePath: 'store/home/shelf',
+    },])
+  })
+
+})

--- a/react/components/ComponentsList/getComponents.ts
+++ b/react/components/ComponentsList/getComponents.ts
@@ -1,0 +1,101 @@
+import { has, path, pathOr } from 'ramda'
+import { ComponentsRegistry } from 'render'
+import { SidebarComponent } from './typings'
+
+const isSamePage = (page: string, pages: string[]) => (treePath: string) => {
+  if (treePath.startsWith(page)) {
+    return true
+  }
+
+  const currentPageLevel = page.split('/').length
+  const sameLevelPages = pages.filter(
+    (p: string) => p.split('/').length === currentPageLevel,
+  )
+
+  return !sameLevelPages.find((p: string) => treePath.startsWith(p))
+}
+
+const getParentContainerPropsGetter = (extensions: Extensions) => (
+  parentPath: string,
+) => {
+  return pathOr<string[], string[]>(
+    [],
+    [parentPath, 'props', 'elements'],
+    extensions,
+  )
+}
+
+const getComponentNameGetterFromExtensions = (extensions: Extensions) => (
+  treePath: string,
+) => extensions[treePath].component || ''
+
+const getComponentSchemaGetter = (
+  components: ComponentsRegistry | null,
+  extensions: Extensions,
+) => (treePath: string) => {
+  const getComponentName = getComponentNameGetterFromExtensions(extensions)
+  const component = getComponentName(treePath)
+  const getSchema = path([component, 'getSchema'], { ...components })
+  return (
+    path([component, 'schema'], { ...components }) ||
+    (typeof getSchema === 'function' && getSchema({}))
+  )
+}
+
+export function getComponents(
+  extensions: Extensions,
+  components: ComponentsRegistry | null,
+  page: string,
+  pages: string[],
+) {
+  const getParentContainerProps = getParentContainerPropsGetter(extensions)
+  const getComponentSchema = getComponentSchemaGetter(components, extensions)
+
+  return Object.keys(extensions)
+    .filter(isSamePage(page, pages))
+    .filter(treePath => {
+      const schema = getComponentSchema(treePath)
+      return !!schema && !!has('title', schema)
+    })
+    .sort((treePathA, treePathB) => {
+      const parentPathA = `${treePathA.split('/')[0]}/${
+        treePathA.split('/')[1]
+      }`
+      const parentPathB = `${treePathB.split('/')[0]}/${
+        treePathB.split('/')[1]
+      }`
+
+      const nameA = treePathA.split('/')[treePathA.split('/').length - 1]
+      const nameB = treePathB.split('/')[treePathB.split('/').length - 1]
+
+      if (parentPathA !== parentPathB) {
+        return 0
+      }
+
+      const parentContainerProps = getParentContainerProps(parentPathA)
+      const firstElementPosition = parentContainerProps.indexOf(nameA)
+      const secondElementPosition = parentContainerProps.indexOf(nameB)
+      const areBothElementsInProps =
+        firstElementPosition !== -1 && secondElementPosition !== -1
+
+      if (
+        areBothElementsInProps &&
+        firstElementPosition > secondElementPosition
+      ) {
+        return 1
+      }
+
+      if (
+        areBothElementsInProps &&
+        firstElementPosition < secondElementPosition
+      ) {
+        return -1
+      }
+
+      return treePathA > treePathB ? 1 : -1
+    })
+    .map<SidebarComponent>(treePath => ({
+      name: getComponentSchema(treePath).title!,
+      treePath,
+    }))
+}

--- a/react/components/ComponentsList/index.tsx
+++ b/react/components/ComponentsList/index.tsx
@@ -42,17 +42,19 @@ class ComponentsList extends Component<
       runtime: iframeRuntime,
     } = this.props
 
+    const components = getComponents(
+      iframeRuntime.extensions,
+      getIframeRenderComponents(),
+      iframeRuntime.page,
+      Object.keys(iframeRuntime.pages),
+    )
+
     return (
       <ToastProvider positioning="parent">
         <ToastConsumer>
           {({ showToast }) => (
             <SortableList
-              components={getComponents(
-                iframeRuntime.extensions,
-                getIframeRenderComponents(),
-                iframeRuntime.page,
-                Object.keys(iframeRuntime.pages),
-              )}
+              components={components}
               editor={editor}
               iframeRuntime={iframeRuntime}
               highlightExtensionPoint={highlightExtensionPoint}

--- a/react/components/ComponentsList/index.tsx
+++ b/react/components/ComponentsList/index.tsx
@@ -1,32 +1,20 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { canUseDOM } from 'render'
 import { ToastConsumer, ToastProvider } from 'vtex.styleguide'
 
-import { getIframeImplementation } from '../../utils/components'
+import { getIframeRenderComponents } from '../../utils/components'
 
 import SortableList from './SortableList'
-import { SidebarComponent } from './typings'
+
+import { getComponents } from './getComponents'
 
 interface Props {
   highlightExtensionPoint: (treePath: string | null) => void
 }
 
-const isDifferentPage = (treePath: string, page: string, pages: string[]) => {
-  if (treePath.startsWith(page)) {
-    return false
-  }
-
-  const currentPageLevel = page.split('/').length
-  const sameLevelPages = pages.filter(
-    (p: string) => p.split('/').length === currentPageLevel,
-  )
-  return !!sameLevelPages.find((p: string) => treePath.startsWith(p))
-}
-
 class ComponentsList extends Component<
   Props & RenderContextProps & EditorContextProps
-  > {
+> {
   public static propTypes = {
     editor: PropTypes.object,
     runtime: PropTypes.object,
@@ -59,7 +47,12 @@ class ComponentsList extends Component<
         <ToastConsumer>
           {({ showToast }) => (
             <SortableList
-              components={this.getComponents()}
+              components={getComponents(
+                iframeRuntime.extensions,
+                getIframeRenderComponents(),
+                iframeRuntime.page,
+                Object.keys(iframeRuntime.pages),
+              )}
               editor={editor}
               iframeRuntime={iframeRuntime}
               highlightExtensionPoint={highlightExtensionPoint}
@@ -70,86 +63,6 @@ class ComponentsList extends Component<
           )}
         </ToastConsumer>
       </ToastProvider>
-    )
-  }
-
-  private getComponentElement = (treePath: string) => {
-    const {
-      editor: { iframeWindow },
-    } = this.props
-
-    if (!canUseDOM) {
-      return undefined
-    }
-
-    return iframeWindow.document.querySelector(
-      `[data-extension-point="${treePath}"]`,
-    )
-  }
-
-  private getComponentSchema(treePath: string) {
-    const {
-      runtime: { extensions },
-    } = this.props
-
-    const { component, props = {} } = extensions[treePath]
-
-    const ComponentImpl =
-      (component && getIframeImplementation(component)) || undefined
-
-    return (
-      ComponentImpl &&
-      ((ComponentImpl.hasOwnProperty('schema') && ComponentImpl.schema) ||
-        (ComponentImpl.getSchema && ComponentImpl.getSchema(props)))
-    )
-}
-
-  private getComponents() {
-    const { runtime } = this.props
-
-    return Object.keys(runtime.extensions)
-      .filter(this.validateExtension)
-      .sort(this.sortComponents)
-      .map<SidebarComponent>(treePath => ({
-        name: this.getComponentSchema(treePath)!.title!,
-        treePath,
-      }))
-  }
-
-  private sortComponents = (treePathA: string, treePathB: string) => {
-    const componentA = this.getComponentElement(treePathA)
-
-    if (!componentA) {
-      return 1
-    }
-
-    const componentB = this.getComponentElement(treePathB)
-
-    if (!componentB) {
-      return -1
-    }
-
-    const { x: xA, y: yA } = componentA.getBoundingClientRect() as DOMRect
-    const { x: xB, y: yB } = componentB.getBoundingClientRect() as DOMRect
-
-    if (yA > yB || (yA === yB && xA > xB)) {
-      return 1
-    }
-
-    return -1
-  }
-
-  private validateExtension = (treePath: string) => {
-    const {
-      runtime: { pages, page },
-    } = this.props
-
-    const schema = this.getComponentSchema(treePath)
-
-    return (
-      schema &&
-      schema.title &&
-      !isDifferentPage(treePath, page, Object.keys(pages))
     )
   }
 }

--- a/react/typings/render.d.ts
+++ b/react/typings/render.d.ts
@@ -16,7 +16,7 @@ declare module 'render' {
     getCustomMessages?: (locale: string) => any
     schema: ComponentSchema
     getSchema?: (any, any?) => ComponentSchema
-    uiSchema: UISchema
+    uiSchema?: UISchema
   }
 
   export interface ComponentsRegistry {

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -12,3 +12,11 @@ export function getIframeImplementation(component: string | null) {
   if (!window) { return null }
   return window.__RENDER_7_COMPONENTS__ && window.__RENDER_7_COMPONENTS__[component]
 }
+
+export function getIframeRenderComponents() {
+  const iframe = document.getElementById('store-iframe') as HTMLIFrameElement
+  if (!iframe) { return null }
+  const window = iframe.contentWindow as Window | null
+  if (!window) { return null }
+  return window.__RENDER_7_COMPONENTS__
+}

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -5,18 +5,30 @@ export function getImplementation(component: string) {
 }
 
 export function getIframeImplementation(component: string | null) {
-  if (component === null) { return null }
+  if (component === null) {
+    return null
+  }
   const iframe = document.getElementById('store-iframe') as HTMLIFrameElement
-  if (!iframe) { return null }
+  if (!iframe) {
+    return null
+  }
   const window = iframe.contentWindow as Window | null
-  if (!window) { return null }
-  return window.__RENDER_7_COMPONENTS__ && window.__RENDER_7_COMPONENTS__[component]
+  if (!window) {
+    return null
+  }
+  return (
+    window.__RENDER_7_COMPONENTS__ && window.__RENDER_7_COMPONENTS__[component]
+  )
 }
 
 export function getIframeRenderComponents() {
   const iframe = document.getElementById('store-iframe') as HTMLIFrameElement
-  if (!iframe) { return null }
+  if (!iframe) {
+    return null
+  }
   const window = iframe.contentWindow as Window | null
-  if (!window) { return null }
+  if (!window) {
+    return null
+  }
   return window.__RENDER_7_COMPONENTS__
 }

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -8,16 +8,10 @@ export function getIframeImplementation(component: string | null) {
   if (component === null) {
     return null
   }
-  const iframe = document.getElementById('store-iframe') as HTMLIFrameElement
-  if (!iframe) {
-    return null
-  }
-  const window = iframe.contentWindow as Window | null
-  if (!window) {
-    return null
-  }
+  const iframeRenderComponents = getIframeRenderComponents()
+
   return (
-    window.__RENDER_7_COMPONENTS__ && window.__RENDER_7_COMPONENTS__[component]
+    iframeRenderComponents && iframeRenderComponents[component]
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Implement new logic for components being rendered using `props.elements` from the extension.

#### What problem is this solving?
Previsible components list order.

#### Types of changes
- [x] New feature (a non-breaking change which adds functionality)
