### PR TITLE
Fix - Highlight overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.1] - 2019-01-02
 ### Fixed
 - **`HighlightOverlay`**
   - Uncovered edge case where a component has two or more DOM elements that alternate visibility based on the user device.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`HighlightOverlay`**
+  - Uncovered edge case where a component has two or more DOM elements that alternate visibility based on the user device.
 
 ## [2.5.0] - 2018-12-05
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/HighlightOverlay.tsx
+++ b/react/HighlightOverlay.tsx
@@ -30,6 +30,13 @@ export default class HighlightOverlay extends Component<Props, State> {
 
   public highlightRemovalTimeout: any
 
+  private INITIAL_HIGHLIGHT_RECT = {
+    height: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  }
+
   constructor(props: any) {
     super(props)
 
@@ -71,19 +78,45 @@ export default class HighlightOverlay extends Component<Props, State> {
     })
   }
 
-  public getHighlightRect = (highlightTreePath : string) => {
-    const element = document.querySelector(`[data-extension-point="${highlightTreePath}"]`)
+  public getHighlightRect = (highlightTreePath: string) => {
+    const elements = document.querySelectorAll(
+      `[data-extension-point="${highlightTreePath}"]`,
+    )
+
     const provider = document.querySelector('.render-provider')
+
     const iframeBody = document.querySelector('body')
-    if (highlightTreePath && element && provider) {
-      const paddingFromIframeBody = iframeBody ? {
-        left: parseInt(window.getComputedStyle(iframeBody, null).paddingLeft || '0', 10),
-        right: parseInt(window.getComputedStyle(iframeBody, null).paddingRight || '0', 10)
-      } : {
-        left: 0, right: 0
+
+    if (highlightTreePath && elements && provider) {
+      const paddingFromIframeBody = iframeBody
+        ? {
+          left: parseInt(
+            window.getComputedStyle(iframeBody, null).paddingLeft || '0',
+            10,
+          ),
+          right: parseInt(
+            window.getComputedStyle(iframeBody, null).paddingRight || '0',
+            10,
+          ),
+        }
+        : {
+          left: 0,
+          right: 0,
       }
-      const rect = element.getBoundingClientRect() as DOMRect
+
       const providerRect = provider.getBoundingClientRect() as DOMRect
+
+      const elementsArray: Element[] = Array.prototype.slice.call(elements)
+
+      const element = elementsArray.find(currElement => {
+        const currRect = currElement.getBoundingClientRect()
+
+        return currRect.width > 0 && currRect.height > 0
+      })
+
+      const rect = element
+        ? element.getBoundingClientRect() as DOMRect
+        : this.INITIAL_HIGHLIGHT_RECT
 
       // Add offset from render provider main div
       rect.y += -providerRect.y


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
`HighlightOverlay` now queries for more than one DOM element for a given `data-extension-point` attribute, and then returns the first non-empty one – i.e., whose both width and height are greater than zero.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Uncovered edge case where a component has two or more DOM elements that alternate visibility based on the user device.

#### How should this be manually tested?
Workspace: https://fixhighlightoverlay--storecomponents.myvtex.com/admin/cms/storefront.

#### Screenshots or example usage
##### Before
![Current behavior](https://user-images.githubusercontent.com/8486092/50454734-9c7c9000-0930-11e9-9d30-0fca1f93faf2.png)
---
##### After
![Post-fix behavior](https://user-images.githubusercontent.com/8486092/50454612-e6b14180-092f-11e9-8274-15881841264f.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue).