### PR TITLE
Highlight overlay and inject menu items on admin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
     "vtex.file-manager": "0.x",
     "vtex.file-manager-graphql": "0.x",
     "vtex.pages-graphql": "2.x",
+    "vtex.store": "2.x",
     "vtex.styleguide": "9.x"
   },
   "mustUpdateAt": "2018-09-05",

--- a/pages/blocks.json
+++ b/pages/blocks.json
@@ -1,0 +1,25 @@
+{
+  "inject#storefront": {
+    "props": {
+      "subItems": [
+        {
+          "isNew": true,
+          "labelId": "pages.admin-menu-button.storefront",
+          "path": "/admin/cms/storefront"
+        },
+        {
+          "isNew": true,
+          "labelId": "pages.admin-menu-button.pages",
+          "path": "/admin/cms/pages"
+        },
+        {
+          "isNew": true,
+          "labelId": "pages.admin-menu-button.displayConditions",
+          "path": "/admin/conditions-builder/pages"
+        }
+      ],
+      "titleId": "appframe.navigation.cms.title",
+      "group": "storeSetup"
+    }
+  }
+}

--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -19,5 +19,8 @@
   },
   "admin.cms-storefront": {
     "component": "PageEditor"
+  },
+  "highlight-overlay.cms": {
+    "component": "HighlightOverlay"
   }
 }

--- a/pages/plugins.json
+++ b/pages/plugins.json
@@ -1,3 +1,3 @@
 {
-  "store > highlight-overlay": "highlight-overlay.cms"
+  "storeWrapper > highlight-overlay": "highlight-overlay.cms"
 }

--- a/pages/plugins.json
+++ b/pages/plugins.json
@@ -1,0 +1,3 @@
+{
+  "store > highlight-overlay": "highlight-overlay.cms"
+}

--- a/pages/plugins.json
+++ b/pages/plugins.json
@@ -1,3 +1,4 @@
 {
-  "storeWrapper > highlight-overlay": "highlight-overlay.cms"
+  "storeWrapper > highlight-overlay": "highlight-overlay.cms",
+  "navigation > inject": "inject#storefront"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Merge `HighlightOverlay` fixes and inject navigation data on admin by using plugins. 

#### What problem is this solving?
Storefront v3 milestone.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

Important: this shouldn't be working yet as some other necessary PRs weren't merged, but they shouldn't break anything either.