### PR TITLE
Change default configuration scope to "specific"

### DIFF
--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -164,11 +164,11 @@ class ConfigurationList extends Component<Props, State> {
     allMatches: true,
     id: '',
     pageContext: this.isSitewide
-      ? this.props.iframeRuntime.route.pageContext
-      : ({
+      ? ({
           id: '*',
           type: '*',
-        } as ExtensionConfiguration['condition']['pageContext']),
+        } as ExtensionConfiguration['condition']['pageContext'])
+      : this.props.iframeRuntime.route.pageContext,
     statements: [],
   })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change default configuration scope to `specific`.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Wrong default configuration scope.

#### How should this be manually tested?
Workspace: https://fixdefaultconfigurationscope--storecomponents.myvtexdev.com/admin/cms/storefront.

#### Screenshots or example usage
#### Before
![image](https://user-images.githubusercontent.com/8486092/53364790-58047500-391e-11e9-87e5-1dae81f11e35.png)

#### After
![image](https://user-images.githubusercontent.com/8486092/53364771-4e7b0d00-391e-11e9-838c-c862df254d1f.png)