### PR TITLE
Fix editing path label i18n

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -103,7 +103,7 @@
   "pages.editor.configuration.tag.sitewide": "Entire site",
   "pages.editor.configuration.tag.subcategory": "Subcategory: {id}",
   "pages.editor.configuration.tag.template": "This template",
-  "pages.editor.container.editpath.label": "Page url",
+  "pages.editor.container.editpath.label": "Page URL",
   "pages.editor.empty-extension.edit": "Click here to edit it",
   "pages.editor.empty-extension.title": "This is an empty extension point",
   "pages.editor.info.page": "Page",

--- a/messages/es.json
+++ b/messages/es.json
@@ -85,7 +85,7 @@
   "pages.editor.configuration.tag.sitewide": "Todo el sitio",
   "pages.editor.configuration.tag.subcategory": "Subcategoría: {id}",
   "pages.editor.configuration.tag.template": "Este template",
-  "pages.editor.container.editpath.label": "Editando",
+  "pages.editor.container.editpath.label": "URL de la página",
   "pages.editor.info.page": "Página",
   "pages.editor.info.title": "Informaciones de la Página"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -103,7 +103,7 @@
   "pages.editor.configuration.tag.sitewide": "Todo o site",
   "pages.editor.configuration.tag.subcategory": "Subcategoria: {id}",
   "pages.editor.configuration.tag.template": "Este template",
-  "pages.editor.container.editpath.label": "Editando",
+  "pages.editor.container.editpath.label": "URL da página",
   "pages.editor.info.page": "Página",
   "pages.editor.info.title": "Informações da Página"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix editing path label i18n.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Outdated i18n texts and lowercase "URL".

#### How should this be manually tested?
Workspace: https://fixeditingpathi18n--storecomponents.myvtexdev.com/admin/cms/storefront.

#### Screenshots or example usage
##### Before
![image](https://user-images.githubusercontent.com/8486092/53366627-d19e6200-3922-11e9-95e1-7e50e2b33d31.png)

##### After
![image](https://user-images.githubusercontent.com/8486092/53366866-6739f180-3923-11e9-83e7-b4e2a2abf3c9.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)