### PR TITLE
Remove listeners on navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `IframeNavigationController` wasn't cleaning up when user decided to navigate.
+
 ## [3.0.0-beta.0] - 2019-02-22
 
 ### Changed


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix bug that navigation wasn't removing listeners.

#### What problem is this solving?
`window.confirm` always showing when there was any change.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
