### PR TITLE
Unset editTreePath and add loading state

### DIFF
--- a/react/components/EditorContainer/Sidebar/ComponentList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/index.tsx
@@ -3,7 +3,12 @@ import React, { Component, Fragment } from 'react'
 import { compose, graphql, MutationFn } from 'react-apollo'
 import { FormattedMessage, InjectedIntlProps, injectIntl } from 'react-intl'
 import { arrayMove, SortEndHandler } from 'react-sortable-hoc'
-import { Button, ButtonWithIcon, ToastConsumerFunctions } from 'vtex.styleguide'
+import {
+  Button,
+  ButtonWithIcon,
+  Spinner,
+  ToastConsumerFunctions,
+} from 'vtex.styleguide'
 
 import UpdateBlock from '../../../../queries/UpdateBlock.graphql'
 import { getBlockPath, getRelativeBlocksIds } from '../../../../utils/blocks'
@@ -72,7 +77,12 @@ class ComponentList extends Component<Props, State> {
   }
 
   public render() {
-    const { intl, onMouseEnterComponent, onMouseLeaveComponent } = this.props
+    const {
+      editor,
+      intl,
+      onMouseEnterComponent,
+      onMouseLeaveComponent,
+    } = this.props
 
     const hasChanges = this.state.changes.length > 0
 
@@ -95,7 +105,12 @@ class ComponentList extends Component<Props, State> {
           })}
         />
         <div className="bb bw1 b--light-silver" />
-        <div className="flex flex-column flex-grow-1">
+        <div className="relative flex flex-column flex-grow-1">
+          {editor.isNavigating && (
+            <div className="absolute bg-white-70 flex h-100 justify-center pt9 w-100 z-2">
+              <Spinner />
+            </div>
+          )}
           {hasChanges && (
             <div className="bb bw1 b--light-silver w-100">
               <div className="w-50 fl tc bw1 br b--light-silver">

--- a/react/components/EditorContainer/Sidebar/Content.tsx
+++ b/react/components/EditorContainer/Sidebar/Content.tsx
@@ -42,6 +42,7 @@ class Content extends Component<Props, State> {
 
     if (currPage !== prevPage) {
       this.resetComponents()
+      this.props.editor.setIsNavigating(false)
     }
   }
 

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -41,7 +41,7 @@ class EditorProvider extends Component<Props, State> {
     components: PropTypes.object,
   }
 
-  private unlisten: (() => void) | void = undefined
+  private unlisten?: (() => void) | void
 
   constructor(props: Props) {
     super(props)

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -5,9 +5,7 @@ import { compose, DataProps } from 'react-apollo'
 import { canUseDOM, withRuntimeContext } from 'vtex.render-runtime'
 import { ToastProvider } from 'vtex.styleguide'
 
-import EditorContainer, {
-  APP_CONTENT_ELEMENT_ID,
-} from './EditorContainer'
+import EditorContainer, { APP_CONTENT_ELEMENT_ID } from './EditorContainer'
 import { EditorContext } from './EditorContext'
 import MessagesContext, { IMessagesContext } from './MessagesContext'
 
@@ -22,6 +20,7 @@ interface State {
   editTreePath: string | null
   iframeRuntime: RenderContext | null
   iframeWindow: Window
+  isNavigating: boolean
   mode: EditorMode
   showAdminControls: boolean
   template?: string
@@ -42,6 +41,8 @@ class EditorProvider extends Component<Props, State> {
     components: PropTypes.object,
   }
 
+  private unlisten: (() => void) | void = undefined
+
   constructor(props: Props) {
     super(props)
 
@@ -52,6 +53,7 @@ class EditorProvider extends Component<Props, State> {
       editTreePath: null,
       iframeRuntime: null,
       iframeWindow: window,
+      isNavigating: false,
       mode: 'content',
       showAdminControls: true,
       template: undefined,
@@ -88,6 +90,22 @@ class EditorProvider extends Component<Props, State> {
         }
 
         this.setState(newState)
+
+        if (
+          this.state.iframeRuntime &&
+          this.state.iframeRuntime.history &&
+          !this.unlisten
+        ) {
+          this.unlisten = this.state.iframeRuntime.history.listen(
+            (_, action) => {
+              const hasNavigated = ['PUSH', 'REPLACE', 'POP'].includes(action)
+              if (hasNavigated) {
+                this.handleSetIsNavigating(true)
+                this.editExtensionPoint(null)
+              }
+            }
+          )
+        }
       }
     }
   }
@@ -136,6 +154,10 @@ class EditorProvider extends Component<Props, State> {
 
     if (!production) {
       emitter.removeListener('localesUpdated', this.emitLocaleEventToIframe)
+    }
+
+    if (this.unlisten) {
+      this.unlisten()
     }
   }
 
@@ -257,6 +279,7 @@ class EditorProvider extends Component<Props, State> {
       editTreePath,
       iframeRuntime,
       iframeWindow,
+      isNavigating,
       mode,
       showAdminControls,
       viewport,
@@ -266,14 +289,17 @@ class EditorProvider extends Component<Props, State> {
       activeConditions,
       addCondition: this.handleAddCondition,
       allMatches,
-      conditions:  this.props.data && this.props.data.availableConditions || [],
+      conditions:
+        (this.props.data && this.props.data.availableConditions) || [],
       editExtensionPoint: this.editExtensionPoint,
       editMode,
       editTreePath,
       iframeWindow,
+      isNavigating,
       mode,
       removeCondition: this.handleRemoveCondition,
       setDevice: this.handleSetDevice,
+      setIsNavigating: this.handleSetIsNavigating,
       setMode: this.handleSetMode,
       setViewport: this.handleSetViewport,
       toggleEditMode: this.handleToggleEditMode,
@@ -300,6 +326,10 @@ class EditorProvider extends Component<Props, State> {
       </ToastProvider>
     )
   }
+
+  private handleSetIsNavigating = (isNavigating: boolean) => {
+    this.setState({ isNavigating })
+  }
 }
 
 const EditorWithMessageContext = (props: Props) => (
@@ -310,6 +340,4 @@ const EditorWithMessageContext = (props: Props) => (
   </MessagesContext.Consumer>
 )
 
-export default compose(
-  withRuntimeContext,
-)(EditorWithMessageContext)
+export default compose(withRuntimeContext)(EditorWithMessageContext)

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -133,9 +133,11 @@ declare global {
     editMode: boolean
     editTreePath: string | null
     iframeWindow: Window
+    isNavigating: boolean
     mode: EditorMode
     viewport: Viewport
     setDevice: (device: ConfigurationDevice) => void
+    setIsNavigating: (isNavigating: boolean) => void
     setMode: (mode: EditorMode) => void
     setViewport: (viewport: Viewport) => void
     editExtensionPoint: (treePath: string | null) => void


### PR DESCRIPTION
#### What is the purpose of this pull request?
Reset component list/configurations selector and add is loading when navigating.

#### What problem is this solving?
User may be editing the wrong component.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
