### PR TITLE
Adapt saveContent mutation's treePath parameter formation logic

### DIFF
--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -6,7 +6,7 @@ import { Spinner, ToastConsumerFunctions } from 'vtex.styleguide'
 
 import ListContent from '../../../../queries/ListContent.graphql'
 import SaveContent from '../../../../queries/SaveContent.graphql'
-import { getBlockPath } from '../../../../utils/blocks'
+import { getBlockPath, getSitewideTreePath } from '../../../../utils/blocks'
 import {
   getComponentSchema,
   getExtension,
@@ -309,6 +309,12 @@ class ConfigurationList extends Component<Props, State> {
       label,
     }
 
+    const treePath = editor.editTreePath!
+
+    const formattedTreePath = this.isSitewide
+      ? getSitewideTreePath(treePath)
+      : treePath
+
     formMeta.toggleLoading()
 
     try {
@@ -318,7 +324,7 @@ class ConfigurationList extends Component<Props, State> {
           template: this.isSitewide
             ? '*'
             : iframeRuntime.pages[iframeRuntime.page].blockId,
-          treePath: editor.editTreePath,
+          treePath: formattedTreePath,
         },
       })
 

--- a/react/utils/blocks/index.ts
+++ b/react/utils/blocks/index.ts
@@ -97,3 +97,6 @@ export const getRelativeBlocksIds = (
         : acc,
     {}
   )
+
+export const getSitewideTreePath = (treePath: string) =>
+  ['*', ...treePath.split('/').slice(1)].join('/')


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Adapt `saveContent` mutation's `treePath` parameter formation logic.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The `saveContent` mutation's `treePath` parameter formation logic has been changed and, therefore, the code must be updated.

#### How should this be manually tested?
Workspace: https://featureadaptcontentsaving--storecomponents.myvtexdev.com/admin/cms/storefront.