### PR TITLE
Fix loading in same path navigation

### DIFF
--- a/react/components/EditorContainer/Sidebar/Content.tsx
+++ b/react/components/EditorContainer/Sidebar/Content.tsx
@@ -37,10 +37,10 @@ class Content extends Component<Props, State> {
     const prevRuntime = prevProps.iframeRuntime
     const currRuntime = this.props.iframeRuntime
 
-    const prevPage = prevRuntime.page
-    const currPage = currRuntime.page
+    const prevPath = prevRuntime.route.path
+    const currPath = currRuntime.route.path
 
-    if (currPage !== prevPage) {
+    if (prevPath !== currPath) {
       this.resetComponents()
       this.props.editor.setIsNavigating(false)
     }

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -97,8 +97,15 @@ class EditorProvider extends Component<Props, State> {
           !this.unlisten
         ) {
           this.unlisten = this.state.iframeRuntime.history.listen(
-            (_, action) => {
-              const hasNavigated = ['PUSH', 'REPLACE', 'POP'].includes(action)
+            (location, action) => {
+              const page = this.state.iframeRuntime!.page
+              const pages = this.state.iframeRuntime!.pages
+              const pathFromCurrentPage = pages[page].path
+
+              const isDifferentPath = pathFromCurrentPage !== location.pathname
+              const hasNavigated =
+                ['PUSH', 'REPLACE', 'POP'].includes(action) && isDifferentPath
+
               if (hasNavigated) {
                 this.handleSetIsNavigating(true)
                 this.editExtensionPoint(null)

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -98,11 +98,14 @@ class EditorProvider extends Component<Props, State> {
         ) {
           this.unlisten = this.state.iframeRuntime.history.listen(
             (location, action) => {
-              const page = this.state.iframeRuntime!.page
-              const pages = this.state.iframeRuntime!.pages
-              const pathFromCurrentPage = pages[page].path
+              const pathFromCurrentPage = this.state.iframeRuntime!.route.path
+              const isRootPath =
+                pathFromCurrentPage === '/' || location.pathname === '/'
 
-              const isDifferentPath = pathFromCurrentPage !== location.pathname
+              const isDifferentPath = isRootPath
+                ? pathFromCurrentPage !== location.pathname
+                : !pathFromCurrentPage.startsWith(location.pathname) // to consider canonicals
+
               const hasNavigated =
                 ['PUSH', 'REPLACE', 'POP'].includes(action) && isDifferentPath
 

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { difference, pathOr, uniq } from 'ramda'
+import { difference, equals, pathOr, uniq } from 'ramda'
 import React, { Component } from 'react'
 import { compose, DataProps } from 'react-apollo'
 import { canUseDOM, withRuntimeContext } from 'vtex.render-runtime'
@@ -101,10 +101,15 @@ class EditorProvider extends Component<Props, State> {
               const pathFromCurrentPage = this.state.iframeRuntime!.route.path
               const isRootPath =
                 pathFromCurrentPage === '/' || location.pathname === '/'
+              const hasParamsChanged = !equals(
+                location.state.navigationRoute.params,
+                this.state.iframeRuntime!.route.params
+              )
 
               const isDifferentPath = isRootPath
                 ? pathFromCurrentPage !== location.pathname
-                : !pathFromCurrentPage.startsWith(location.pathname) // to consider canonicals
+                : !pathFromCurrentPage.startsWith(location.pathname) ||
+                  hasParamsChanged // to consider canonicals
 
               const hasNavigated =
                 ['PUSH', 'REPLACE', 'POP'].includes(action) && isDifferentPath

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -88,6 +88,7 @@ declare global {
     listen: (
       listenCb: (location: HistoryLocation, action: string) => void
     ) => () => void
+    location: HistoryLocation
   }
 
   interface RenderContext {
@@ -171,7 +172,7 @@ declare global {
     version: string
     culture: Culture
     pages: Routes
-    route: { pageContext: PageContext }
+    route: { pageContext: PageContext; path: string }
     routes: Routes
     extensions: Extensions
     production: boolean

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -80,7 +80,7 @@ declare global {
     key: string
     pathname: string
     search: string
-    state: {}
+    state: { navigationRoute: { params: {} } }
   }
 
   type RuntimeHistory = History & {
@@ -172,7 +172,7 @@ declare global {
     version: string
     culture: Culture
     pages: Routes
-    route: { pageContext: PageContext; path: string }
+    route: { pageContext: PageContext; path: string; params: {} }
     routes: Routes
     extensions: Extensions
     production: boolean

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -75,9 +75,19 @@ declare global {
     [name: string]: Route
   }
 
+  interface HistoryLocation {
+    hash: string
+    key: string
+    pathname: string
+    search: string
+    state: {}
+  }
+
   type RuntimeHistory = History & {
     block: (s: string) => () => void
-    listen: (listenCb: (location: string, action: string) => void) => () => void
+    listen: (
+      listenCb: (location: HistoryLocation, action: string) => void
+    ) => () => void
   }
 
   interface RenderContext {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make loading more consistent when navigating.

#### What problem is this solving?
When navigating to same path, the sidebar entered its loading state and would get stuck in it because the "stop loading" condition is a change in route.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

[ch7233]