### PR TITLE
Fix layout persistence and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.0-beta.5] - 2019-03-26
+
 ## [3.0.0-beta.4] - 2019-03-19
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/HighlightOverlay.tsx
+++ b/react/HighlightOverlay.tsx
@@ -1,3 +1,4 @@
+import debounce from 'lodash.debounce'
 import PropTypes from 'prop-types'
 import React, { Component, CSSProperties } from 'react'
 import { canUseDOM } from 'vtex.render-runtime'
@@ -37,6 +38,10 @@ export default class HighlightOverlay extends Component<Props, State> {
     y: 0,
   }
 
+  private debouncedScrollTo = debounce((element: Element) => {
+    element.scrollIntoView({ behavior: 'smooth' })
+  }, 75)
+
   constructor(props: any) {
     super(props)
 
@@ -60,6 +65,9 @@ export default class HighlightOverlay extends Component<Props, State> {
 
   public componentDidUpdate() {
     this.updateExtensionPointDOMElements(this.state.editMode)
+    if (this.state.highlightTreePath === null) {
+      this.debouncedScrollTo.cancel()
+    }
   }
 
   public updateExtensionPointDOMElements = (editMode: boolean) => {
@@ -128,7 +136,7 @@ export default class HighlightOverlay extends Component<Props, State> {
         : this.INITIAL_HIGHLIGHT_RECT
 
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth' })
+        this.debouncedScrollTo(element)
       }
 
       // Add offset from render provider main div

--- a/react/Wrapper.tsx
+++ b/react/Wrapper.tsx
@@ -6,7 +6,7 @@ interface Props {
   children?: ReactNode
 }
 
-const Wrapper: React.SFC<Props> = ({ children }) => (
+const Wrapper: React.FunctionComponent<Props> = ({ children }) => (
   <ToastProvider positioning="window">
     <AdminLoadingContextProvider>{children}</AdminLoadingContextProvider>
   </ToastProvider>

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
@@ -28,7 +28,7 @@ interface CustomProps {
 
 type Props = CustomProps & ReactIntl.InjectedIntlProps
 
-const ComponentEditor: React.SFC<Props> = ({
+const ComponentEditor: React.FunctionComponent<Props> = ({
   after,
   data,
   editor,

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ActionMenu.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ActionMenu.tsx
@@ -13,11 +13,10 @@ interface Props {
 const ActionMenu: React.SFC<Props> = ({ options }) => (
   <StyleguideActionMenu
     buttonProps={{
-      icon: true,
+      icon: <IconOptionsDots />,
       variation: 'tertiary',
     }}
     hideCaretIcon
-    icon={<IconOptionsDots />}
     options={options}
   />
 )

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ActionMenu.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ActionMenu.tsx
@@ -10,7 +10,7 @@ interface Props {
   options: ActionMenuOption[]
 }
 
-const ActionMenu: React.SFC<Props> = ({ options }) => (
+const ActionMenu: React.FunctionComponent<Props> = ({ options }) => (
   <StyleguideActionMenu
     buttonProps={{
       icon: <IconOptionsDots />,

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/DragHandle.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/DragHandle.tsx
@@ -6,11 +6,16 @@ import ComponentDragHandleIcon from '../../../../../icons/ComponentDragHandleIco
 import SideItem from './SideItem'
 
 interface Props {
+  isExpandable: boolean
   onMouseEnter: () => void
 }
 
-const DragHandle = SortableHandle<Props>(({ onMouseEnter }) => (
-  <SideItem isPointer onMouseEnter={onMouseEnter}>
+const DragHandle = SortableHandle<Props>(({ isExpandable, onMouseEnter }) => (
+  <SideItem
+    horizontalPaddingClassName={isExpandable ? 'pl3 pr2' : undefined}
+    isPointer
+    onMouseEnter={onMouseEnter}
+  >
     <ComponentDragHandleIcon />
   </SideItem>
 ))

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.css
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.css
@@ -1,0 +1,5 @@
+.transition {
+  transition-property: transform, color;
+  transition-duration: 200ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.tsx
@@ -1,26 +1,36 @@
+import classnames from 'classnames'
 import React from 'react'
-
 import ArrowIcon from '../../../../../icons/ArrowIcon'
 
 import SideItem from './SideItem'
 
+import styles from './ExpandArrow.css'
+
 interface Props {
-  hasRightMargin?: boolean
+  hasLeftMargin?: boolean
   isExpanded: boolean
   onClick: () => void
 }
 
-const ExpandArrow: React.SFC<Props> = ({
-  hasRightMargin,
+const ExpandArrow: React.FunctionComponent<Props> = ({
+  hasLeftMargin,
   isExpanded,
   onClick,
 }) => (
-  <SideItem isPointer onClick={onClick}>
+  <SideItem horizontalPaddingClassName="ph2" isPointer onClick={onClick}>
     <div
-      className={`flex items-center ${isExpanded ? '' : 'rotate-90'}`}
-      style={hasRightMargin ? { marginRight: '44px' } : undefined}
+      className={classnames(`flex items-center color-inherit`, {
+        'pl6 ml2': hasLeftMargin,
+      })}
+      style={hasLeftMargin ? {} : { marginRight: 3 }}
     >
-      <ArrowIcon />
+      <div
+        className={classnames('color-inherit', styles['transition'], {
+          'rotate-90': isExpanded,
+        })}
+      >
+        <ArrowIcon />
+      </div>
     </div>
   </SideItem>
 )

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
@@ -1,8 +1,10 @@
+import classnames from 'classnames'
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
 interface Props {
-  hasLeftPadding?: boolean
+  hasSubItems?: boolean
+  isSortable?: boolean
   isChild?: boolean
   onEdit: (event: React.MouseEvent<HTMLDivElement>) => void
   onMouseEnter: (event: React.MouseEvent<HTMLDivElement>) => void
@@ -12,33 +14,51 @@ interface Props {
 }
 
 const Item: React.SFC<Props> = ({
-  hasLeftPadding,
+  hasSubItems,
+  isSortable,
   isChild,
   onEdit,
   onMouseEnter,
   onMouseLeave,
   title,
   treePath,
-}) => (
-  <div
-    className={`w-100 pv5 pr0 dark-gray bg-inherit tl ${
-      hasLeftPadding ? 'pl7' : 'pl0'
-    }`}
-    data-tree-path={treePath}
-    key={treePath}
-    onClick={onEdit}
-    onMouseEnter={onMouseEnter}
-    onMouseLeave={onMouseLeave}
-    style={{ animationDuration: '0.2s' }}
-  >
-    <FormattedMessage id={title}>
-      {text => (
-        <span className={`f6 fw4 track-1 ${isChild ? 'pl7' : 'pl2'}`}>
-          {text}
-        </span>
+}) => {
+  let leftPaddingClassName = 'pl8'
+  if (isChild) {
+    leftPaddingClassName = 'pl6'
+  } else if (isSortable && !hasSubItems) {
+    leftPaddingClassName = 'pl5'
+  } else if (isSortable) {
+    leftPaddingClassName = 'pl2'
+  } else if (hasSubItems) {
+    leftPaddingClassName = 'pl3'
+  }
+
+  return (
+    <div
+      className={classnames(
+        'w-100 pv5 pr0 dark-gray bg-inherit tl',
+        leftPaddingClassName
       )}
-    </FormattedMessage>
-  </div>
-)
+      data-tree-path={treePath}
+      key={treePath}
+      onClick={onEdit}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        ...{ animationDuration: '0.2s' },
+        ...(!hasSubItems || isSortable ? { marginLeft: 1 } : null),
+      }}
+    >
+      <FormattedMessage id={title}>
+        {text => (
+          <span className={`f6 fw4 track-1 ${isChild ? 'pl7' : 'pl2'}`}>
+            {text}
+          </span>
+        )}
+      </FormattedMessage>
+    </div>
+  )
+}
 
 export default Item

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
@@ -13,7 +13,7 @@ interface Props {
   treePath: string
 }
 
-const Item: React.SFC<Props> = ({
+const Item: React.FunctionComponent<Props> = ({
   hasSubItems,
   isSortable,
   isChild,

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/SideItem.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/SideItem.tsx
@@ -1,26 +1,35 @@
+import classnames from 'classnames'
 import React from 'react'
 
 interface Props {
+  horizontalPaddingClassName?: string
   isPointer?: boolean
   onClick?: () => void
   onMouseEnter?: (event: React.MouseEvent<HTMLDivElement>) => void
 }
 
-const SideItem: React.SFC<Props> = ({
+const SideItem: React.FunctionComponent<Props> = ({
   children,
+  horizontalPaddingClassName,
   isPointer,
   onClick,
   onMouseEnter,
 }) => (
   <div
-    className={`flex items-center ph3 pv5 bg-inherit dark-gray ${
-      isPointer ? 'pointer' : ''
-    }`}
+    className={classnames(
+      `flex items-center pv5 bg-inherit c-muted-3 hover-black-90`,
+      { pointer: isPointer },
+      horizontalPaddingClassName
+    )}
     onClick={onClick}
     onMouseEnter={onMouseEnter}
   >
     {children}
   </div>
 )
+
+SideItem.defaultProps = {
+  horizontalPaddingClassName: 'ph3',
+}
 
 export default SideItem

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
@@ -60,23 +60,27 @@ class SortableListItem extends Component<Props, State> {
           onMouseLeave={onMouseLeave}
         >
           {component.isSortable && (
-            <DragHandle onMouseEnter={this.handleMouseEnter} />
+            <DragHandle
+              onMouseEnter={this.handleMouseEnter}
+              isExpandable={!!subitems}
+            />
+          )}
+          {subitems && (
+            <ExpandArrow
+              hasLeftMargin={!component.isSortable}
+              isExpanded={this.state.isExpanded}
+              onClick={this.toggleExpansion}
+            />
           )}
           <Item
-            hasLeftPadding={!component.isSortable}
+            hasSubItems={!!subitems}
+            isSortable={component.isSortable}
             onEdit={onEdit}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             title={component.name}
             treePath={component.treePath}
           />
-          {subitems && (
-            <ExpandArrow
-              hasRightMargin={!component.isSortable}
-              isExpanded={this.state.isExpanded}
-              onClick={this.toggleExpansion}
-            />
-          )}
           {component.isSortable && (
             <ActionMenu options={this.actionMenuOptions} />
           )}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/ScopeSelector.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/ScopeSelector.tsx
@@ -13,7 +13,7 @@ interface CustomProps {
 
 type Props = CustomProps & InjectedIntlProps
 
-const ScopeSelector: React.SFC<Props> = ({
+const ScopeSelector: React.FunctionComponent<Props> = ({
   intl,
   isSitewide,
   onChange,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/index.tsx
@@ -13,7 +13,7 @@ interface CustomProps {
 
 type Props = CustomProps & InjectedIntlProps
 
-const ScopeSelector: React.SFC<Props> = ({
+const ScopeSelector: React.FunctionComponent<Props> = ({
   intl,
   isSitewide,
   onChange,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
@@ -25,7 +25,7 @@ interface Props {
   shouldDisableSaveButton: boolean
 }
 
-const ContentEditor: React.SFC<Props> = ({
+const ContentEditor: React.FunctionComponent<Props> = ({
   condition,
   configuration,
   editor,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
@@ -42,17 +42,12 @@ const ContentEditor: React.SFC<Props> = ({
 }) => {
   const extension = getExtension(editor.editTreePath, iframeRuntime.extensions)
 
-  const extensionContent = {
-    component: extension.component || null,
-    ...extension.content,
-  }
-
   const content = configuration
     ? {
         ...(configuration.contentJSON && JSON.parse(configuration.contentJSON)),
-        ...extensionContent,
+        ...extension.content,
       }
-    : extensionContent
+    : extension.content
 
   return (
     <ComponentEditor

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/LayoutEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/LayoutEditor/index.tsx
@@ -65,10 +65,7 @@ class LayoutEditor extends Component<Props> {
       iframeRuntime.extensions
     )
 
-    return {
-      component: extension.component || null,
-      ...extension.props,
-    }
+    return extension.props
   }
 
   private handleChange = (event: IChangeEvent) => {

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/Tag.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/Tag.tsx
@@ -8,7 +8,7 @@ interface Props {
   textColor: string
 }
 
-const Tag: React.SFC<Props> = ({
+const Tag: React.FunctionComponent<Props> = ({
   bgColor,
   borderColor,
   hasBorder,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/List/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/List/index.tsx
@@ -21,7 +21,7 @@ interface Props {
   title?: string
 }
 
-const List: React.SFC<Props> = ({
+const List: React.FunctionComponent<Props> = ({
   configurations,
   editor,
   isDisabledChecker,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -293,7 +293,8 @@ class ConfigurationList extends Component<Props, State> {
       componentImplementation,
       content,
       iframeRuntime,
-      intl
+      intl,
+      true
     )
 
     const contentId =

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -26,7 +26,7 @@ const NEW_CONFIGURATION_ID = 'new'
 
 interface ListContentQuery {
   error: object
-  listContent: ExtensionConfiguration[]
+  listContent?: ExtensionConfiguration[]
   loading: boolean
   refetch: (variables?: object) => void
 }
@@ -122,7 +122,7 @@ class ConfigurationList extends Component<Props, State> {
     if (!this.state.configuration) {
       return (
         <List
-          configurations={listContentQuery.listContent}
+          configurations={listContentQuery.listContent || []}
           editor={editor}
           iframeRuntime={iframeRuntime}
           isDisabledChecker={this.isConfigurationDisabled}

--- a/react/components/EditorContainer/Sidebar/EditorHeader/SaveButton.tsx
+++ b/react/components/EditorContainer/Sidebar/EditorHeader/SaveButton.tsx
@@ -16,17 +16,19 @@ const SaveButton = ({
   onClick,
   variation,
 }: Props & ReactIntl.InjectedIntlProps) => (
-  <Button
-    disabled={isDisabled}
-    isLoading={isLoading}
-    onClick={onClick}
-    size="small"
-    variation={variation}
-  >
-    {intl.formatMessage({
-      id: 'pages.editor.components.button.save',
-    })}
-  </Button>
+  <div className="nv3">
+    <Button
+      disabled={isDisabled}
+      isLoading={isLoading}
+      onClick={onClick}
+      size="small"
+      variation={variation}
+    >
+      {intl.formatMessage({
+        id: 'pages.editor.components.button.save',
+      })}
+    </Button>
+  </div>
 )
 
 export default injectIntl(SaveButton)

--- a/react/components/EditorContainer/Sidebar/EditorHeader/index.tsx
+++ b/react/components/EditorContainer/Sidebar/EditorHeader/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   title?: string
 }
 
-const EditorHeader: React.SFC<Props> = ({
+const EditorHeader: React.FunctionComponent<Props> = ({
   editor,
   isLoading,
   onClose,

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -15,7 +15,7 @@ interface CustomProps {
 
 type Props = CustomProps & ReactIntl.InjectedIntlProps
 
-const Sidebar: React.SFC<Props> = ({
+const Sidebar: React.FunctionComponent<Props> = ({
   editor,
   highlightHandler,
   intl,

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -3,11 +3,11 @@ import { ComponentsRegistry } from 'vtex.render-runtime'
 
 import { SidebarComponent } from './typings'
 
-const isSamePage = (page: string, treePath: string) => {
-  const pageHead = page.split('/')[0]
-  const treePathHead = treePath.split('/')[0]
+const isSamePage = (page?: string, treePath?: string) => {
+  const pageHead = page && page.split('/')[0]
+  const treePathHead = treePath && treePath.split('/')[0]
 
-  return treePathHead === pageHead
+  return pageHead && treePathHead && treePathHead === pageHead
 }
 
 const getParentContainerPropsGetter = (extensions: Extensions) => (

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/ColorEditor.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/ColorEditor.tsx
@@ -59,7 +59,11 @@ const fieldName = (id: string) => {
   }
 }
 
-const ColorsEditor: React.SFC<Props> = ({ colorInfo, updateColor, token }) => {
+const ColorsEditor: React.FunctionComponent<Props> = ({
+  colorInfo,
+  updateColor,
+  token,
+}) => {
   const groups = groupBy(info => {
     return fieldName(info.path.split('.')[0])
   }, colorInfo)

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/ColorGroup.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/ColorGroup.tsx
@@ -14,7 +14,7 @@ interface Props {
   semanticColors: SemanticColors
 }
 
-const ColorGroup: React.SFC<Props> = ({
+const ColorGroup: React.FunctionComponent<Props> = ({
   colorsInfo,
   font,
   groupName,
@@ -56,7 +56,7 @@ interface ColorPreviewProps {
   token: string
 }
 
-const ColorPreview: React.SFC<ColorPreviewProps> = ({
+const ColorPreview: React.FunctionComponent<ColorPreviewProps> = ({
   colorInfo,
   previewInfo,
   startEditing,

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/ColorsEditor/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 type EditMode = string | undefined
 
-const ColorsEditor: React.SFC<Props> = ({
+const ColorsEditor: React.FunctionComponent<Props> = ({
   addNavigation,
   font,
   semanticColors,

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/StyleEditorTools.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/StyleEditorTools.tsx
@@ -15,7 +15,7 @@ type NavigationReducer = (
   info: NavigationUpdate
 ) => NavigationInfo[]
 
-const StyleEditorTools: React.SFC<Props> = ({
+const StyleEditorTools: React.FunctionComponent<Props> = ({
   children,
   initialState,
   saveStyle,

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleEditor/index.tsx
@@ -38,7 +38,7 @@ type ConfigReducer = (
   partialConfig: Partial<TachyonsConfig>
 ) => TachyonsConfig
 
-const Editor: React.SFC<EditorProps> = ({
+const Editor: React.FunctionComponent<EditorProps> = ({
   addNavigation,
   config,
   updateConfig,
@@ -106,7 +106,7 @@ const Editor: React.SFC<EditorProps> = ({
   )
 }
 
-const StyleEditor: React.SFC<Props> = ({
+const StyleEditor: React.FunctionComponent<Props> = ({
   stopEditing,
   style,
   setStyleAsset,

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleList/StyleCard/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleList/StyleCard/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   style: Style
 }
 
-const StyleCard: React.SFC<Props> = ({
+const StyleCard: React.FunctionComponent<Props> = ({
   deleteStyle,
   duplicateStyle,
   selectStyle,

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleList/icons/CreateNewIcon.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleList/icons/CreateNewIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // TODO: Use tachyons on stroke color
-const CreateNewIcon: React.SFC = () => (
+const CreateNewIcon: React.FunctionComponent = () => (
   <svg
     width="14"
     height="14"

--- a/react/components/EditorContainer/StoreEditor/Styles/StyleList/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/StyleList/index.tsx
@@ -30,7 +30,10 @@ const compareStyles = (a: Style, b: Style) => {
   }, 0)
 }
 
-const StyleList: React.SFC<Props> = ({ startEditing, setStyleAsset }) => {
+const StyleList: React.FunctionComponent<Props> = ({
+  startEditing,
+  setStyleAsset,
+}) => {
   return (
     <Operations>
       {({

--- a/react/components/EditorContainer/StoreEditor/Styles/components/Colors.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/components/Colors.tsx
@@ -4,7 +4,7 @@ interface Props {
   colors: string[]
 }
 
-const Colors: React.SFC<Props> = ({ colors }) => (
+const Colors: React.FunctionComponent<Props> = ({ colors }) => (
   <div className="flex ba br2 b--muted-5 bg-muted-5 overflow-hidden">
     {colors.map((color, index) => (
       <div

--- a/react/components/EditorContainer/StoreEditor/Styles/components/Typography.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/components/Typography.tsx
@@ -5,7 +5,7 @@ interface Props {
   textColor?: string
 }
 
-const Typography: React.SFC<Props> = ({
+const Typography: React.FunctionComponent<Props> = ({
   typography: {
     fontFamily,
     fontSize,

--- a/react/components/EditorContainer/StoreEditor/Styles/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/index.tsx
@@ -63,7 +63,7 @@ const removeStyleTag = (window: Window, id: string) => {
   }
 }
 
-const Styles: React.SFC<Props> = ({ iframeWindow }) => {
+const Styles: React.FunctionComponent<Props> = ({ iframeWindow }) => {
   const [editing, setEditing] = useState<EditingState>(undefined)
 
   useEffect(() => {

--- a/react/components/EditorContainer/StoreEditor/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/index.tsx
@@ -14,7 +14,7 @@ const Mode = ({ editor, mode }: Props) => {
   }
 }
 
-const StoreEditor: React.SFC<Props> = (props: Props) => {
+const StoreEditor: React.FunctionComponent<Props> = (props: Props) => {
   return (
     <div
       className="h-100 mr5 bg-base ba b--muted-4 br3"

--- a/react/components/EditorContainer/Topbar/components/ModeButton.tsx
+++ b/react/components/EditorContainer/Topbar/components/ModeButton.tsx
@@ -37,7 +37,7 @@ const getTitle = (mode?: StoreEditMode) => {
   }[mode]
 }
 
-const ModeButton: React.SFC<Props> = ({ changeMode, mode }) => {
+const ModeButton: React.FunctionComponent<Props> = ({ changeMode, mode }) => {
   return (
     <div
       className="pointer mh3 h-3em w4 flex justify-center items-center"

--- a/react/components/EditorContainer/Topbar/components/icons/BackArrowIcon.tsx
+++ b/react/components/EditorContainer/Topbar/components/icons/BackArrowIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // TODO: Use tachyons on stroke color
-const BackArrowIcon: React.SFC = () => (
+const BackArrowIcon: React.FunctionComponent = () => (
   <svg
     width="13"
     height="10"

--- a/react/components/EditorContainer/Topbar/components/icons/CustomizeIcon.tsx
+++ b/react/components/EditorContainer/Topbar/components/icons/CustomizeIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const CustomizeIcon: React.SFC = () => (
+const CustomizeIcon: React.FunctionComponent = () => (
   <svg
     width="16"
     height="16"

--- a/react/components/EditorContainer/Topbar/components/icons/SettingsIcon.tsx
+++ b/react/components/EditorContainer/Topbar/components/icons/SettingsIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const SettingsIcon: React.SFC = () => (
+const SettingsIcon: React.FunctionComponent = () => (
   <svg
     width="16"
     height="16"

--- a/react/components/EditorContainer/Topbar/components/icons/TemplateIcon.tsx
+++ b/react/components/EditorContainer/Topbar/components/icons/TemplateIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const TemplateIcon: React.SFC = () => (
+const TemplateIcon: React.FunctionComponent = () => (
   <svg
     width="18"
     height="16"

--- a/react/components/EditorContainer/Topbar/index.tsx
+++ b/react/components/EditorContainer/Topbar/index.tsx
@@ -11,7 +11,11 @@ interface Props {
   urlPath: string
 }
 
-const Topbar: React.SFC<Props> = ({ changeMode, mode, urlPath }) => (
+const Topbar: React.FunctionComponent<Props> = ({
+  changeMode,
+  mode,
+  urlPath,
+}) => (
   <div className="ph5 f6 h-3em w-100 flex justify-between items-center">
     <div className="flex items-stretch">
       {mode ? (

--- a/react/components/Select.tsx
+++ b/react/components/Select.tsx
@@ -12,7 +12,7 @@ interface SelectProps {
 
 type Props = SelectProps & InjectedIntlProps
 
-const Select: React.SFC<Props> = ({
+const Select: React.FunctionComponent<Props> = ({
   errorMessage,
   onChange,
   options,
@@ -23,7 +23,7 @@ const Select: React.SFC<Props> = ({
     <ReactSelect
       className={`f6 ${!!errorMessage ? 'b--danger bw1' : ''}`}
       arrowRenderer={(
-        { onMouseDown, isOpen }: any, // ArrowRendererProps isn't defining isOpen.
+        { onMouseDown, isOpen }: any // ArrowRendererProps isn't defining isOpen.
       ) => (
         <div onMouseDown={onMouseDown}>
           {isOpen ? (
@@ -36,7 +36,7 @@ const Select: React.SFC<Props> = ({
       multi
       onChange={optionValues => {
         const formattedValue = (optionValues as Option[]).map(
-          (item: Option) => item.value as string,
+          (item: Option) => item.value as string
         )
         onChange(formattedValue)
       }}

--- a/react/components/admin/pages/Form/ConditionalTemplatePicker.tsx
+++ b/react/components/admin/pages/Form/ConditionalTemplatePicker.tsx
@@ -34,7 +34,7 @@ export interface ConditionalTemplatePickerProps {
 
 type Props = ConditionalTemplatePickerProps & ReactIntl.InjectedIntlProps
 
-export const ConditionalTemplatePicker: React.SFC<Props> = ({
+export const ConditionalTemplatePicker: React.FunctionComponent<Props> = ({
   condition,
   formErrors,
   intl,

--- a/react/components/admin/pages/Form/ConditionalTemplateSection.tsx
+++ b/react/components/admin/pages/Form/ConditionalTemplateSection.tsx
@@ -30,7 +30,7 @@ export interface ConditionalTemplateSectionProps
 
 type Props = ConditionalTemplateSectionProps & ReactIntl.InjectedIntlProps
 
-export const ConditionalTemplateSection: React.SFC<Props> = ({
+export const ConditionalTemplateSection: React.FunctionComponent<Props> = ({
   detailChangeHandlerGetter,
   formErrors,
   intl,

--- a/react/components/admin/pages/Form/Form.tsx
+++ b/react/components/admin/pages/Form/Form.tsx
@@ -40,7 +40,7 @@ interface CustomProps extends TemplateSectionProps {
 
 type Props = CustomProps & ReactIntl.InjectedIntlProps
 
-const Form: React.SFC<Props> = ({
+const Form: React.FunctionComponent<Props> = ({
   data,
   detailChangeHandlerGetter,
   formErrors,

--- a/react/components/admin/pages/Form/SectionTitle.tsx
+++ b/react/components/admin/pages/Form/SectionTitle.tsx
@@ -5,7 +5,7 @@ interface Props {
   textId: string
 }
 
-const SectionTitle: React.SFC<Props> = ({ textId }) => (
+const SectionTitle: React.FunctionComponent<Props> = ({ textId }) => (
   <FormattedMessage id={textId}>
     {text => <h2 className="mv7 f5 normal">{text}</h2>}
   </FormattedMessage>

--- a/react/components/admin/pages/Form/Title.tsx
+++ b/react/components/admin/pages/Form/Title.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const Title: React.SFC = ({ children }) => (
+const Title: React.FunctionComponent = ({ children }) => (
   <h1 className="mb7 pb7 bb bw1 b--light-silver f3 normal">{children}</h1>
 )
 

--- a/react/components/admin/pages/List/index.tsx
+++ b/react/components/admin/pages/List/index.tsx
@@ -9,7 +9,7 @@ interface Props {
   categorizedRoutes: CategorizedRoutes
 }
 
-const List: React.SFC<Props> = ({ categorizedRoutes }) => (
+const List: React.FunctionComponent<Props> = ({ categorizedRoutes }) => (
   <Fragment>
     <Section
       hasCreateButton

--- a/react/components/form/ArrayFieldTemplate.tsx
+++ b/react/components/form/ArrayFieldTemplate.tsx
@@ -135,7 +135,7 @@ class ArrayFieldTemplate extends Component<
   }
 }
 
-const StatelessArrayFieldTemplate: React.SFC<
+const StatelessArrayFieldTemplate: React.FunctionComponent<
   ArrayFieldTemplateProps
 > = props => <ArrayFieldTemplate {...props} />
 

--- a/react/components/form/BaseInput.tsx
+++ b/react/components/form/BaseInput.tsx
@@ -11,7 +11,7 @@ interface Props extends WidgetProps {
   type?: string
 }
 
-const BaseInput: React.SFC<WidgetProps & Props> = props => {
+const BaseInput: React.FunctionComponent<WidgetProps & Props> = props => {
   const {
     autofocus,
     disabled,

--- a/react/components/form/Dropdown.tsx
+++ b/react/components/form/Dropdown.tsx
@@ -24,7 +24,7 @@ const getChangeHandler = (
 ) => ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) =>
   onChange(!value ? emptyValue : value)
 
-const Dropdown: React.SFC<DropdownProps> = ({
+const Dropdown: React.FunctionComponent<DropdownProps> = ({
   autofocus,
   disabled,
   id,

--- a/react/components/form/ErrorListTemplate.tsx
+++ b/react/components/form/ErrorListTemplate.tsx
@@ -35,7 +35,7 @@ class ErrorListTemplate extends Component<ErrorListProps, State> {
       (currErrors.length > 0 &&
         currErrors.reduce(
           (acc, error, index) => error.stack !== prevErrors[index].stack || acc,
-          false,
+          false
         ))
 
     if (!isVisible && haveErrorsChanged) {
@@ -48,7 +48,7 @@ class ErrorListTemplate extends Component<ErrorListProps, State> {
     const { isVisible } = this.state
 
     const container = document.getElementById(
-      'form__error-list-template___alert',
+      'form__error-list-template___alert'
     )
 
     return (
@@ -63,7 +63,7 @@ class ErrorListTemplate extends Component<ErrorListProps, State> {
             </Alert>
           </div>
         ),
-        container,
+        container
       )
     )
   }
@@ -86,8 +86,8 @@ class ErrorListTemplate extends Component<ErrorListProps, State> {
   }
 }
 
-const StatelessErrorListTemplate: React.SFC<ErrorListProps> = props => (
-  <ErrorListTemplate {...props} />
-)
+const StatelessErrorListTemplate: React.FunctionComponent<
+  ErrorListProps
+> = props => <ErrorListTemplate {...props} />
 
 export default StatelessErrorListTemplate

--- a/react/components/form/FieldTemplate.tsx
+++ b/react/components/form/FieldTemplate.tsx
@@ -11,7 +11,7 @@ interface Props {
   schema: JSONSchema6
 }
 
-const FieldTemplate: React.SFC<Props & FieldTemplateProps> = ({
+const FieldTemplate: React.FunctionComponent<Props & FieldTemplateProps> = ({
   children,
   classNames,
   formContext,

--- a/react/components/form/ImageUploader/Dropzone.tsx
+++ b/react/components/form/ImageUploader/Dropzone.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const MAX_SIZE = 4 * 1024 * 1024
 
-const Dropzone: React.SFC<Props> = ({
+const Dropzone: React.FunctionComponent<Props> = ({
   disabled,
   children,
   extraClasses,

--- a/react/components/form/ImageUploader/ErrorAlert.tsx
+++ b/react/components/form/ImageUploader/ErrorAlert.tsx
@@ -5,7 +5,7 @@ interface Props {
   message: string
 }
 
-const ErrorAlert: React.SFC<Props> = ({ message }) => {
+const ErrorAlert: React.FunctionComponent<Props> = ({ message }) => {
   const [isVisible, setIsVisible] = useState<boolean>(true)
 
   return isVisible ? (

--- a/react/components/form/MultiSelect.tsx
+++ b/react/components/form/MultiSelect.tsx
@@ -19,7 +19,7 @@ interface Props {
   value: string[]
 }
 
-const MultiSelect: React.SFC<Props> = ({
+const MultiSelect: React.FunctionComponent<Props> = ({
   autofocus,
   disabled,
   id,

--- a/react/components/form/ObjectFieldTemplate.tsx
+++ b/react/components/form/ObjectFieldTemplate.tsx
@@ -28,7 +28,7 @@ interface Props extends ObjectFieldTemplateProps {
   formContext: ComponentEditorFormContext
 }
 
-const ObjectFieldTemplate: React.SFC<Props> = ({
+const ObjectFieldTemplate: React.FunctionComponent<Props> = ({
   formContext,
   properties,
   schema,

--- a/react/components/form/SimpleFormattedMessage.tsx
+++ b/react/components/form/SimpleFormattedMessage.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
-const SimpleFormattedMessage: React.SFC<{
-  id: string;
-}> = ({ id }) => (<FormattedMessage id={id}>{txt => <>{txt}</>}</FormattedMessage>)
+const SimpleFormattedMessage: React.FunctionComponent<{
+  id: string
+}> = ({ id }) => (
+  <FormattedMessage id={id}>{txt => <>{txt}</>}</FormattedMessage>
+)
 
 export default SimpleFormattedMessage

--- a/react/components/form/TextArea.tsx
+++ b/react/components/form/TextArea.tsx
@@ -19,7 +19,7 @@ interface Props extends WidgetProps {
  * - onFocus: FocusEventHandler<HTMLTextAreaElement>
  */
 
-const TextArea: React.SFC<Props> = ({
+const TextArea: React.FunctionComponent<Props> = ({
   autofocus,
   disabled,
   id,

--- a/react/components/form/Toggle.tsx
+++ b/react/components/form/Toggle.tsx
@@ -16,7 +16,7 @@ interface Props {
   value?: boolean
 }
 
-const Toggle: React.SFC<WidgetProps & Props> = ({
+const Toggle: React.FunctionComponent<WidgetProps & Props> = ({
   autofocus,
   disabled,
   id,

--- a/react/components/icons/AddIcon.tsx
+++ b/react/components/icons/AddIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const AddIcon: React.SFC = () => (
+const AddIcon: React.FunctionComponent = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
     <path
       d="M8 5.42773V10.5706"

--- a/react/components/icons/ArrowIcon.tsx
+++ b/react/components/icons/ArrowIcon.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 
-const ArrowIcon: React.SFC = () => (
-  <svg width="20" height="20" viewBox="0 0 16 16" fill="none">
-    <g clipPath="url(#clip0)">
-      <rect width="20" height="20" fill="none" />
-      <path d="M8 10.5L11.5 7L4.5 7L8 10.5Z" fill="#727273" />
-    </g>
-    <defs>
-      <clipPath id="clip0">
-        <rect width="20" height="20" fill="none" />
-      </clipPath>
-    </defs>
+interface Props {
+  color?: string
+}
+
+const ArrowIcon: React.FunctionComponent<Props> = ({ color }) => (
+  <svg
+    width="5"
+    height="9"
+    viewBox="0 0 5 9"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 8.5L5 4.5L0 0.5V8.5Z" fill={color} />
   </svg>
 )
+
+ArrowIcon.defaultProps = {
+  color: 'currentColor',
+}
 
 export default ArrowIcon

--- a/react/components/icons/ComponentDragHandleIcon.tsx
+++ b/react/components/icons/ComponentDragHandleIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const ComponentDragHandleIcon: React.SFC = () => (
+const ComponentDragHandleIcon: React.FunctionComponent = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
     <circle cx="10" cy="3" r="1" fill="#CACBCC" />
     <circle cx="10" cy="8" r="1" fill="#CACBCC" />

--- a/react/components/icons/DragHandle.tsx
+++ b/react/components/icons/DragHandle.tsx
@@ -11,7 +11,11 @@ const iconBase = {
   width: 6,
 }
 
-const DragHandle: React.SFC<Props> = ({ size, className, ...props }) => {
+const DragHandle: React.FunctionComponent<Props> = ({
+  size,
+  className,
+  ...props
+}) => {
   const newSize = calcIconSize(iconBase, size as number) // TS doesn't detect defaultProps
 
   return (

--- a/react/components/icons/GearIcon.tsx
+++ b/react/components/icons/GearIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const GearIcon: React.SFC = () => (
+const GearIcon: React.FunctionComponent = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
     <g clipPath="url(#clip0)">
       <path

--- a/react/components/icons/TrashSimple.tsx
+++ b/react/components/icons/TrashSimple.tsx
@@ -10,7 +10,7 @@ interface Props {
   size?: number
 }
 
-const TrashSimple: React.SFC<Props> = ({ size, ...props }) => {
+const TrashSimple: React.FunctionComponent<Props> = ({ size, ...props }) => {
   const newSize = calcIconSize(iconBase, size as number) // TS doesn't detect defaultProps
 
   return (

--- a/react/components/icons/UndoIcon.tsx
+++ b/react/components/icons/UndoIcon.tsx
@@ -4,7 +4,7 @@ interface Props {
   color?: string
 }
 
-const UndoIcon: React.SFC<Props> = ({ color }) => (
+const UndoIcon: React.FunctionComponent<Props> = ({ color }) => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
     <rect width="16" height="16" fill="none" />
     <path

--- a/react/images/ImageIcon.tsx
+++ b/react/images/ImageIcon.tsx
@@ -5,7 +5,7 @@ interface Props {
   stroke?: string
 }
 
-const ImageIcon: React.SFC<Props> = ({ size, stroke }) => (
+const ImageIcon: React.FunctionComponent<Props> = ({ size, stroke }) => (
   <svg
     width={`${size}px`}
     height={`${size}px`}

--- a/react/images/SelectionIcon.tsx
+++ b/react/images/SelectionIcon.tsx
@@ -4,7 +4,7 @@ interface Props {
   stroke: string
 }
 
-const SelectionIcon: React.SFC<Props> = ({ stroke }) => (
+const SelectionIcon: React.FunctionComponent<Props> = ({ stroke }) => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
     <rect width="24" height="24" fill="white" />
     <path

--- a/react/images/ShowIcon.tsx
+++ b/react/images/ShowIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const ShowIcon: React.SFC<{}> = () => (
+const ShowIcon: React.FunctionComponent<{}> = () => (
   <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1">
     <g
       stroke="none"

--- a/react/package.json
+++ b/react/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "exenv": "^1.2.2",
+    "lodash.debounce": "^4.0.8",
     "lodash.startcase": "^4.4.0",
     "ramda": "^0.25.0",
     "react-draggable": "^3.0.5",
@@ -24,6 +25,7 @@
     "@types/graphql": "^0.12.5",
     "@types/intl": "^1.2.0",
     "@types/jest": "^23.3.9",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.startcase": "^4.4.4",
     "@types/prop-types": "^15.5.2",
     "@types/ramda": "types/npm-ramda#dist",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -4,10 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "lib": ["es2017", "dom"],
-    "module": "es6",
-    "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es2017",
     "skipLibCheck": true,
     "strict": true,
     "typeRoots": ["node_modules/@types"]

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -213,10 +213,9 @@ export const updateExtensionFromForm = (
   runtime: RenderContext,
   isContent?: boolean
 ) => {
-  const { component: enumComponent } = event.formData
-  const component = enumComponent && enumComponent !== '' ? enumComponent : null
-  const componentImplementation =
-    component && getIframeImplementation(component)
+  const extension = editTreePath ? runtime.extensions[editTreePath] : null
+  const component = extension ? extension.component : null
+  const componentImplementation = getIframeImplementation(component)
 
   const propsOrContent = getSchemaPropsOrContent(
     componentImplementation,

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -180,7 +180,8 @@ export const getSchemaPropsOrContent = (
   ): object =>
     reduce(
       (nextPropsOrContent, key) =>
-        !properties[key].isLayout === isContent
+        !properties[key].isLayout === isContent ||
+        properties[key].type === 'object'
           ? merge(nextPropsOrContent, {
               [key]:
                 properties[key].type === 'object'

--- a/react/utils/components.ts
+++ b/react/utils/components.ts
@@ -160,7 +160,8 @@ export const getSchemaPropsOrContent = (
   component: RenderComponent<any, any> | null,
   propsOrContent: object,
   runtime: RenderContext,
-  intl: ReactIntl.InjectedIntl
+  intl: ReactIntl.InjectedIntl,
+  isContent: boolean = false
 ) => {
   if (!component) {
     return null
@@ -173,20 +174,33 @@ export const getSchemaPropsOrContent = (
    * @param {object} prevPropsOrContent The previous props or content passed to the component
    * @return {object} Actual component props or content
    */
-  const getPropsOrContentFromSchema = (properties: any = {}, prevPropsOrContent: any): object =>
+  const getPropsOrContentFromSchema = (
+    properties: any = {},
+    prevPropsOrContent: any
+  ): object =>
     reduce(
       (nextPropsOrContent, key) =>
-        merge(nextPropsOrContent, {
-          [key]:
-            properties[key].type === 'object'
-              ? getPropsOrContentFromSchema(properties[key].properties, prevPropsOrContent[key])
-              : prevPropsOrContent[key],
-        }),
+        !properties[key].isLayout === isContent
+          ? merge(nextPropsOrContent, {
+              [key]:
+                properties[key].type === 'object'
+                  ? getPropsOrContentFromSchema(
+                      properties[key].properties,
+                      prevPropsOrContent[key]
+                    )
+                  : prevPropsOrContent[key],
+            })
+          : nextPropsOrContent,
       {},
       filter(v => prevPropsOrContent[v] !== undefined, keys(properties))
     )
 
-  const componentSchema = getComponentSchema(component, propsOrContent, runtime, intl)
+  const componentSchema = getComponentSchema(
+    component,
+    propsOrContent,
+    runtime,
+    intl
+  )
 
   return getPropsOrContentFromSchema(componentSchema.properties, propsOrContent)
 }
@@ -207,7 +221,8 @@ export const updateExtensionFromForm = (
     componentImplementation,
     event.formData,
     runtime,
-    intl
+    intl,
+    isContent
   )
 
   runtime.updateExtension(editTreePath as string, {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -50,6 +50,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/lodash.debounce@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.startcase@^4.4.4":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/lodash.startcase/-/lodash.startcase-4.4.5.tgz#fba70ba04d370d9b71a4ad5c2ac256ea97369fab"
@@ -3455,6 +3462,11 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 lodash.escape@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix layout x content persistence and other fixes.

#### What problem is this solving?
- [x] Separate layout and content props when saving.
- [x] Debounce scroll on hover.
- [x] Change arrow icon.
- [x] Change its position to before the component name and fix padding/spacing.

#### How should this be manually tested?
[https://fixlayoutpersistence--storecomponents.myvtex.com/admin/cms/storefront](https://fixlayoutpersistence--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
