### PR TITLE
Fix store setting button intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.0-beta.9] - 2019-04-08
+
 ### Fixed
 - Add settings button's intl id into `context.json`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add settings button's intl id into `context.json`.
+
 ## [3.0.0-beta.8] - 2019-04-08
+
 ### Changed
 - Bump to new `pwa-graphql` major.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/messages/context.json
+++ b/messages/context.json
@@ -108,6 +108,7 @@
   "pages.editor.container.editpath.label": "pages.editor.container.editpath.label",
   "pages.editor.store.button.template.title": "pages.editor.store.button.template.title",
   "pages.editor.store.button.theme.title": "pages.editor.store.button.theme.title",
+  "pages.editor.store.button.settings.title": "Store",
   "pages.editor.store.button.back.title": "Back to editor",
   "pages.editor.store.settings.title": "General Settings",
   "pages.editor.store.settings.error.title": "Something went wrong",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

There was no `pages.editor.store.button.settings.title` id in `context.json` file.

#### How should this be manually tested?

[Access the workspace](https://pwa--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

Before

![image](https://user-images.githubusercontent.com/15948386/55741442-a029b380-5a03-11e9-9242-188f448cd3f9.png)

After

![image](https://user-images.githubusercontent.com/15948386/55741476-b3d51a00-5a03-11e9-95c4-283174ac37c5.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
