### PR TITLE
Fix - Configuration behavior

### DIFF
--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -216,7 +216,7 @@ class ConfigurationList extends Component<Props, State> {
   }
 
   private handleConfigurationClose = () => {
-    const { formMeta, modal } = this.props
+    const { editor, formMeta, iframeRuntime, modal } = this.props
 
     if (formMeta.wasModified) {
       modal.open()
@@ -225,6 +225,10 @@ class ConfigurationList extends Component<Props, State> {
         if (modal.isOpen) {
           modal.close()
         }
+
+        iframeRuntime.updateRuntime({
+          conditions: editor.activeConditions,
+        })
       })
     }
   }
@@ -404,18 +408,12 @@ class ConfigurationList extends Component<Props, State> {
     updateExtensionFromForm(editTreePath, event, intl, iframeRuntime, true)
   }
 
-  private handleQuit = (event?: any) => {
-    const { editor, iframeRuntime } = this.props
-
+  private handleQuit = (event?: Event) => {
     if (event) {
       event.stopPropagation()
     }
 
-    iframeRuntime.updateRuntime({
-      conditions: editor.activeConditions,
-    })
-
-    editor.editExtensionPoint(null)
+    this.props.editor.editExtensionPoint(null)
   }
 
   private isConfigurationDisabled = (configuration: ExtensionConfiguration) => {

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -209,10 +209,7 @@ class ConfigurationList extends Component<Props, State> {
         iframeRuntime.updateExtension(editor.editTreePath!, {
           ...iframeRuntime.extensions[editor.editTreePath!],
           component: extension.component,
-          content:
-            newConfiguration.contentId === NEW_CONFIGURATION_ID
-              ? extension.content
-              : JSON.parse(newConfiguration.contentJSON),
+          content: JSON.parse(newConfiguration.contentJSON),
         })
       }
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Change the form default values' source for new content configurations from iframe's runtime to component schema;
- Change the moment that `updateRuntime` is called from the end of component editing to the end of content configuration editing.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
- Non-default values are being used as default when a new content configuration is created;
- It's confusing not to see the "active" configuration's content being displayed in the iframe when looking at the configuration list.

#### How should this be manually tested?
Workspace: https://fixconfigurationbehavior--storecomponents.myvtex.com/admin/cms/storefront.
