### PR TITLE
Makes messages query before setting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.0] - 2019-04-24
+
 ## [3.2.1] - 2019-04-23
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {
@@ -25,7 +25,9 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish -r vtex --verbose"

--- a/react/components/DomainMessages.ts
+++ b/react/components/DomainMessages.ts
@@ -1,0 +1,51 @@
+import ApolloClient from 'apollo-client'
+import { keys, reduce } from 'ramda'
+
+import messagesForDomainQuery from '../queries/MessagesForDomain.graphql'
+
+interface Props {
+  runtime: RenderContext
+  domain: string
+  client: ApolloClient<any>
+}
+
+interface Message {
+  key: string
+  message: string
+}
+
+interface Data {
+  messages: Message[]
+}
+
+interface Variables {
+  components: string[]
+  domain: string
+  renderMajor: number
+}
+
+const messagesToReactIntlFormat = (messages: Message[]) =>
+  reduce(
+    (acc, { key, message }) => ({ ...acc, [key]: message }),
+    {} as Record<string, string>,
+    messages
+  )
+
+export const editorMessagesFromRuntime = async ({
+  client,
+  domain,
+  runtime,
+}: Props) => {
+  const { components, renderMajor } = runtime
+  const {
+    data: { messages },
+  } = await client.query<Data, Variables>({
+    query: messagesForDomainQuery,
+    variables: {
+      components: keys(components),
+      domain,
+      renderMajor,
+    },
+  })
+  return messagesToReactIntlFormat(messages)
+}

--- a/react/queries/MessagesForDomain.graphql
+++ b/react/queries/MessagesForDomain.graphql
@@ -1,0 +1,6 @@
+query GetMessagesForDomain($components: [String!]!, $domain: String!, $renderMajor: Int!) {
+  messages(components: $components, domain: $domain, renderMajor: $renderMajor) {
+    key
+    message
+  }
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -109,6 +109,7 @@ declare global {
     preview: RenderRuntime['preview']
     production: RenderRuntime['production']
     route: RenderRuntime['route']
+    renderMajor: RenderRuntime['renderMajor']
     setDevice: (device: ConfigurationDevice) => void
     updateComponentAssets: (availableComponents: Components) => void
     updateExtension: (name: string, extension: Extension) => void


### PR DESCRIPTION
#### What is the purpose of this pull request?
Before setting messages, we should query pages-graphql asking for the messages of the correct domain and components for generating the store editor

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
