### PR TITLE
Add sticky property to tabs at Store Settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.6.0] - 2019-05-03
+
 ### Added
 
 - **EditorContainer**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **EditorContainer**
+  - Add `sticky` property to tabs at Store Settings menu.
+
 ## [3.5.2] - 2019-05-02
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {
@@ -25,7 +25,9 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish -r vtex --verbose"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/components/EditorContainer/StoreEditor/Store/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/index.tsx
@@ -14,7 +14,7 @@ const Store: React.FunctionComponent<InjectedIntlProps> = ({ intl }) => {
         <FormattedMessage id="admin/pages.editor.store.settings.title" />
       </div>
       <div className="flex">
-        <Tabs>
+        <Tabs sticky>
           <Tab
             active={activeTab === 'general'}
             onClick={() => setActiveTab('general')}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

Improving UX with this sticky tabs. Better when switching contexts.

#### How should this be manually tested?

[Access the workspace](https://pwa--storecomponents.myvtex.com/admin/cms/storefront) and see it working in the Store Settings menu.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/56831924-da3ae800-6840-11e9-8cb9-fea1ccc6c9fc.png)
![image](https://user-images.githubusercontent.com/15948386/56831940-e030c900-6840-11e9-9cc7-eaf1825c94a8.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
