### PR TITLE
Passing blockId to SaveContent mutation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Passing `blockId` on `SaveContent` mutation.
+
 ## [3.5.1] - 2019-05-02
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.2] - 2019-05-02
+
 ### Fixed
 
 - Passing `blockId` on `SaveContent` mutation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -340,7 +340,7 @@ class ConfigurationList extends Component<Props, State> {
     }
 
     const blockId = path<string>(
-      ['extensions', iframeRuntime.page, 'blockId'],
+      ['extensions', editor.editTreePath || '', 'blockId'],
       iframeRuntime
     )
 

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -1,4 +1,4 @@
-import { clone } from 'ramda'
+import { clone, path } from 'ramda'
 import React, { Component } from 'react'
 import { injectIntl } from 'react-intl'
 import { IChangeEvent } from 'react-jsonschema-form'
@@ -339,11 +339,17 @@ class ConfigurationList extends Component<Props, State> {
         (this.state.configuration && this.state.configuration.origin) || null,
     }
 
+    const blockId = path<string>(
+      ['extensions', iframeRuntime.page, 'blockId'],
+      iframeRuntime
+    )
+
     formMeta.toggleLoading()
 
     try {
       await saveContent({
         variables: {
+          blockId,
           configuration,
           template,
           treePath,

--- a/react/components/EditorContainer/graphql/SaveContent.graphql
+++ b/react/components/EditorContainer/graphql/SaveContent.graphql
@@ -1,9 +1,11 @@
 mutation saveContent(
+  $blockId: String
   $configuration: ContentConfigurationInput
   $template: String
   $treePath: String
 ) {
   saveContent(
+    blockId: $blockId
     configuration: $configuration
     template: $template
     treePath: $treePath

--- a/react/components/EditorContainer/mutations/SaveContent.tsx
+++ b/react/components/EditorContainer/mutations/SaveContent.tsx
@@ -6,6 +6,7 @@ interface SaveContentData {
 }
 
 interface SaveContentVariables {
+  blockId?: string
   configuration: Omit<ExtensionConfiguration, 'contentId'> & {
     contentId: string | null
   }


### PR DESCRIPTION
#### What problem is this solving?
Always save content for the current block instead of getting the best one available (for `header`, `footer` and other blocks that are saved for multiple templates).

#### Workspace
[https://fixsavecontent--storecomponents.myvtex.com/admin/cms/storefront](https://fixsavecontent--storecomponents.myvtex.com/admin/cms/storefront)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
