### PR TITLE
Add the Prompt on Custom Event Toggle to PWA Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **EditorContainer**
+  - Add `promptOnCustomEvent` toggle in the PWA Form to allow events like click the BuyButton to prompt the PWA installation modal.
+
 ## [3.7.1] - 2019-05-10
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -168,6 +168,8 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-primary": "admin/pages.editor.store.settings.pwa.orientation.portrait-primary",
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "admin/pages.editor.store.settings.pwa.orientation.portrait",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event": "admin/pages.editor.store.settings.pwa.prompt-on-custom-event",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description": "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "admin/pages.editor.store.settings.pwa.screen-orientation",
   "admin/pages.editor.store.settings.pwa.splash-screen": "admin/pages.editor.store.settings.pwa.splash-screen",
   "admin/pages.editor.store.settings.pwa.start_url": "admin/pages.editor.store.settings.pwa.start_url",

--- a/messages/en.json
+++ b/messages/en.json
@@ -168,6 +168,8 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-primary": "Portrait (Primary)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Portrait (Secondary)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Portrait",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event": "Prompt \"Add to Home Screen\" based on user interaction",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description": "For now, only available in add to cart event",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Screen Orientation",
   "admin/pages.editor.store.settings.pwa.splash-screen": "Splash screen (iOS)",
   "admin/pages.editor.store.settings.pwa.start_url": "Start URL",

--- a/messages/es.json
+++ b/messages/es.json
@@ -169,7 +169,7 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Retrato (Secundario)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Retrato",
   "admin/pages.editor.store.settings.pwa.prompt-on-custom-event": "Mostrar modal de instalación basado en la interacción del usuario",
-  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.display": "Por ahora, sólo disponible en eventos de añadir a la cesta de la compra",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description": "Por ahora, sólo disponible en eventos de añadir a la cesta de la compra",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Orientación de la pantalla",
   "admin/pages.editor.store.settings.pwa.splash-screen": "Pantalla de carga (iOS)",
   "admin/pages.editor.store.settings.pwa.start_url": "URL inicial",

--- a/messages/es.json
+++ b/messages/es.json
@@ -168,6 +168,8 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-primary": "Retrato (Primario)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Retrato (Secundario)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Retrato",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event": "Mostrar modal de instalación basado en la interacción del usuario",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.display": "Por ahora, sólo disponible en eventos de añadir a la cesta de la compra",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Orientación de la pantalla",
   "admin/pages.editor.store.settings.pwa.splash-screen": "Pantalla de carga (iOS)",
   "admin/pages.editor.store.settings.pwa.start_url": "URL inicial",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -168,6 +168,8 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-primary": "Retrato (Primário)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Retrato (Secundário)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Retrato",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event": "Exibir modal de instalação baseado na interação do usuário",
+  "admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description": "Por enquanto, só disponível em eventos de adicionar ao carrinho",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Orientação da Tela",
   "admin/pages.editor.store.settings.pwa.splash-screen": "Tela de carregamento (iOS)",
   "admin/pages.editor.store.settings.pwa.start_url": "URL inicial",

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SortableContainer } from 'react-sortable-hoc'
+import { SortableContainer, SortableContainerProps } from 'react-sortable-hoc'
 
 import { NormalizedComponent } from '../typings'
 
@@ -17,7 +17,9 @@ interface CustomProps {
 
 type Props = CustomProps
 
-const SortableList = SortableContainer<Props>(
+const SortableList: React.ComponentClass<
+  Props & SortableContainerProps
+> = SortableContainer<Props>(
   ({ components, onDelete, onEdit, onMouseEnter, onMouseLeave }) => (
     <ul className="mv0 pl0 overflow-y-auto pointer">
       {components.map((component, index) => (

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
@@ -14,6 +14,7 @@ export interface PWAImage {
 
 export interface PWASettings {
   disablePrompt: boolean
+  promptOnCustomEvent: boolean
 }
 
 export interface Manifest {

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
@@ -302,6 +302,24 @@ const PWAForm: React.FunctionComponent<Props> = ({
           }
         />
       </div>
+      <div className="pt6">
+        <Toggle
+          label={intl.formatMessage({
+            id: 'admin/pages.editor.store.settings.pwa.prompt-on-custom-event',
+          })}
+          checked={settings.promptOnCustomEvent}
+          disabled={submitting || settings.disablePrompt}
+          onChange={() =>
+            setSettings({
+              ...settings,
+              promptOnCustomEvent: !settings.promptOnCustomEvent,
+            })
+          }
+        />
+        <div className="c-muted-1 t-small mt3 lh-title">
+          <FormattedMessage id="admin/pages.editor.store.settings.pwa.prompt-on-custom-event.description" />
+        </div>
+      </div>
       <div className="w-100 mt7 tr">
         <Button
           size="small"

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/queries/PWA.graphql
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/queries/PWA.graphql
@@ -24,6 +24,7 @@ query PWA {
   }
   pwaSettings {
     disablePrompt
+    promptOnCustomEvent
   }
 
   # Styles

--- a/react/components/EditorContainer/StoreEditor/Store/StoreForm/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/StoreForm/index.tsx
@@ -104,7 +104,7 @@ const StoreForm: React.FunctionComponent<Props> = ({ store, intl, mutate }) => {
     schemas.title = intl.formatMessage({ id: schema.title })
     schemas.schema = assoc(
       'properties',
-      formatSchema(dissoc('title', schema).properties, intl),
+      formatSchema(schema.properties, intl),
       schema
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

Now events like clicking the BuyButton can prompt the "Add to Home Screen" modal.

#### How should this be manually tested?

[Workspace](https://prompt--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/57543557-1125f900-732b-11e9-89a1-c9e082d507c7.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
