### PR TITLE
Make highlight-overlay lazy to not be loaded on store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Highlight overlay assets being loaded on store
+
 ## [3.8.0] - 2019-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.8.1] - 2019-05-17
+
 ### Fixed
 
 - Highlight overlay assets being loaded on store

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -28,7 +28,8 @@
   },
   "highlight-overlay.cms": {
     "component": "HighlightOverlay",
-    "extensible": "vtex"
+    "extensible": "vtex",
+    "render": "lazy"
   },
   "pages-wrapper": {
     "component": "PagesAdminWrapper"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make highlight-overlay lazy to not be loaded on store

#### What problem is this solving?
`vtex.admin-pages` assets are being loaded on store

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/2726345/57944778-696e7500-78ae-11e9-9527-347e4e03f206.png)

After (linked workspace):
![image](https://user-images.githubusercontent.com/2726345/57944868-b6524b80-78ae-11e9-97d2-94f8aa31a9d4.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
