### PR TITLE
Fix - Configuration list behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.8.2] - 2019-05-21
+
 ### Changed
 
 - When deleting a configuration, keep the loader until the configuration has been deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When deleting a configuration, keep the loader until the configuration has been deleted.
+
+### Fixed
+
+- Inconsistent content edition caused by desynchronized Runtimes.
+- Configuration list not being updated after creating/deleting configurations.
+
 ## [3.8.1] - 2019-05-17
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/EditorContainer/IframeNavigationController.tsx
+++ b/react/components/EditorContainer/IframeNavigationController.tsx
@@ -15,8 +15,10 @@ const maybeCall = (fn: (() => void) | void) => {
 const IframeNavigationController: React.FunctionComponent<Props> = ({
   iframeRuntime,
 }) => {
-  const { wasModified, setWasModified } = useFormMetaContext()
+  const { getWasModified, setWasModified } = useFormMetaContext()
   const { editExtensionPoint } = useEditorContext()
+
+  const wasModified = getWasModified()
 
   useEffect(
     () => {

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
@@ -1,7 +1,7 @@
 import { JSONSchema6 } from 'json-schema'
 import React, { Fragment } from 'react'
 import { injectIntl } from 'react-intl'
-import { IChangeEvent } from 'react-jsonschema-form'
+import { FormProps } from 'react-jsonschema-form'
 
 import {
   getComponentSchema,
@@ -10,6 +10,7 @@ import {
 } from '../../../../utils/components'
 import { useEditorContext } from '../../../EditorContext'
 import EditorHeader from '../EditorHeader'
+import { useFormMetaContext } from '../FormMetaContext'
 
 import Form from './Form'
 import { getUiSchema } from './utils'
@@ -21,7 +22,7 @@ interface CustomProps {
   iframeRuntime: RenderContext
   isContent?: boolean
   isLoading: boolean
-  onChange: (event: IChangeEvent) => void
+  onChange: FormProps<object>['onChange']
   onClose: () => void
   onSave: () => void
   shouldDisableSaveButton: boolean
@@ -82,6 +83,8 @@ const ComponentEditor: React.FunctionComponent<Props> = ({
         <div className="relative bg-white flex flex-column justify-between size-editor w-100 pb3 ph5">
           <Form
             formContext={{
+              addMessages: iframeRuntime.addMessages,
+              messages: iframeRuntime.messages,
               isLayoutMode: mode === 'layout',
             }}
             formData={data}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
@@ -2,8 +2,6 @@ import { JSONSchema6 } from 'json-schema'
 import React, { Fragment } from 'react'
 import { IChangeEvent } from 'react-jsonschema-form'
 
-import { getExtension } from '../../../../../utils/components'
-import { useEditorContext } from '../../../../EditorContext'
 import ComponentEditor from '../../ComponentEditor'
 
 import ConditionControls from './ConditionControls'
@@ -14,7 +12,9 @@ interface Props {
   condition: ExtensionConfiguration['condition']
   configuration?: ExtensionConfiguration
   contentSchema?: JSONSchema6
+  data?: object
   iframeRuntime: RenderContext
+  isDefault: boolean
   isLoading: boolean
   isSitewide: boolean
   label?: string
@@ -31,11 +31,12 @@ interface Props {
 const ContentEditor: React.FunctionComponent<Props> = ({
   componentTitle,
   condition,
-  configuration,
   contentSchema,
+  data = {},
   iframeRuntime,
-  isSitewide,
+  isDefault,
   isLoading,
+  isSitewide,
   label,
   onClose,
   onConditionChange,
@@ -43,49 +44,34 @@ const ContentEditor: React.FunctionComponent<Props> = ({
   onLabelChange,
   onSave,
   shouldDisableSaveButton,
-}) => {
-  const { editTreePath } = useEditorContext()
-
-  const extension = getExtension(editTreePath, iframeRuntime.extensions)
-
-  const content = configuration
-    ? {
-        ...(configuration.contentJSON && JSON.parse(configuration.contentJSON)),
-        ...extension.content,
-      }
-    : extension.content
-
-  const isDefault = !!(configuration && configuration.origin)
-
-  return (
-    <ComponentEditor
-      after={
-        <Fragment>
-          <div className="pt5 ph5 bt bw1 b--light-silver">
-            <LabelEditor onChange={onLabelChange} value={label || ''} />
-          </div>
-          {!isDefault ? (
-            <ConditionControls
-              condition={condition}
-              isSitewide={isSitewide}
-              pageContext={iframeRuntime.route.pageContext}
-              onConditionChange={onConditionChange}
-            />
-          ) : null}
-        </Fragment>
-      }
-      contentSchema={contentSchema}
-      data={content}
-      iframeRuntime={iframeRuntime}
-      isContent
-      isLoading={isLoading}
-      onChange={onFormChange}
-      onClose={onClose}
-      onSave={onSave}
-      shouldDisableSaveButton={shouldDisableSaveButton}
-      title={componentTitle}
-    />
-  )
-}
+}) => (
+  <ComponentEditor
+    after={
+      <Fragment>
+        <div className="pt5 ph5 bt bw1 b--light-silver">
+          <LabelEditor onChange={onLabelChange} value={label || ''} />
+        </div>
+        {!isDefault ? (
+          <ConditionControls
+            condition={condition}
+            isSitewide={isSitewide}
+            pageContext={iframeRuntime.route.pageContext}
+            onConditionChange={onConditionChange}
+          />
+        ) : null}
+      </Fragment>
+    }
+    contentSchema={contentSchema}
+    data={data}
+    iframeRuntime={iframeRuntime}
+    isContent
+    isLoading={isLoading}
+    onChange={onFormChange}
+    onClose={onClose}
+    onSave={onSave}
+    shouldDisableSaveButton={shouldDisableSaveButton}
+    title={componentTitle}
+  />
+)
 
 export default ContentEditor

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/index.tsx
@@ -1,6 +1,6 @@
 import { JSONSchema6 } from 'json-schema'
 import React, { Fragment } from 'react'
-import { IChangeEvent } from 'react-jsonschema-form'
+import { FormProps } from 'react-jsonschema-form'
 
 import ComponentEditor from '../../ComponentEditor'
 
@@ -22,7 +22,7 @@ interface Props {
   onConditionChange: (
     changes: Partial<ExtensionConfiguration['condition']>
   ) => void
-  onFormChange: (event: IChangeEvent) => void
+  onFormChange: FormProps<object>['onChange']
   onLabelChange: (event: Event) => void
   onSave: () => void
   shouldDisableSaveButton: boolean

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/LayoutEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/LayoutEditor/index.tsx
@@ -41,11 +41,11 @@ class LayoutEditor extends Component<Props> {
       <ComponentEditor
         data={this.getExtensionProps()}
         iframeRuntime={iframeRuntime}
-        isLoading={formMeta.isLoading && !modal.isOpen}
+        isLoading={formMeta.getIsLoading() && !modal.isOpen}
         onChange={this.handleChange}
         onClose={this.handleExit}
         onSave={this.handleSave}
-        shouldDisableSaveButton={!formMeta.wasModified}
+        shouldDisableSaveButton={!formMeta.getWasModified()}
       />
     )
   }
@@ -68,7 +68,7 @@ class LayoutEditor extends Component<Props> {
   private handleChange = (event: IChangeEvent) => {
     const { editor, formMeta, iframeRuntime } = this.props
 
-    if (!formMeta.wasModified) {
+    if (!formMeta.getWasModified()) {
       formMeta.setWasModified(true)
     }
 
@@ -98,7 +98,7 @@ class LayoutEditor extends Component<Props> {
   private handleExit = () => {
     const { formMeta, modal } = this.props
 
-    if (formMeta.wasModified) {
+    if (formMeta.getWasModified()) {
       modal.open()
     } else {
       this.exit()

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -435,11 +435,11 @@ class ConfigurationList extends React.Component<Props, State> {
         },
       })
 
-      editor.setIsLoading(false)
-
       this.props.iframeRuntime.updateRuntime()
 
       await this.refetchConfigurations()
+
+      editor.setIsLoading(false)
 
       this.props.showToast({
         horizontalPosition: 'right',

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -235,7 +235,7 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleConfigurationClose = () => {
     const { editor, formMeta, iframeRuntime, modal } = this.props
 
-    if (formMeta.wasModified) {
+    if (formMeta.getWasModified()) {
       modal.open()
     } else {
       this.setState(

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -76,7 +76,6 @@ class ConfigurationList extends React.Component<Props, State> {
   private componentImplementation: RenderComponent<any, any> | null
   private componentProperties: ComponentSchema['properties']
   private componentTitle: ComponentSchema['title']
-  private configurations: ExtensionConfiguration[]
   private contentSchema: JSONSchema6
   private defaultFormData: object
 
@@ -124,8 +123,6 @@ class ConfigurationList extends React.Component<Props, State> {
         runtime: iframeRuntime,
       }) || {}
 
-    this.configurations = (listContent && listContent.content) || []
-
     modal.setHandlers({
       actionHandler: this.handleConfigurationSave,
       cancelHandler: this.handleConfigurationDiscard,
@@ -137,7 +134,11 @@ class ConfigurationList extends React.Component<Props, State> {
   }
 
   public render() {
-    const { editor, formMeta, iframeRuntime, modal } = this.props
+    const { editor, formMeta, iframeRuntime, modal, queryData } = this.props
+
+    const listContent = queryData && queryData.listContentWithSchema
+
+    const configurations = (listContent && listContent.content) || []
 
     const shouldEnableSaveButton =
       (this.state.configuration &&
@@ -148,7 +149,7 @@ class ConfigurationList extends React.Component<Props, State> {
     if (!this.state.configuration) {
       return (
         <List
-          configurations={this.configurations}
+          configurations={configurations}
           editor={editor}
           isDisabledChecker={this.isConfigurationDisabled}
           isSitewide={this.props.isSitewide}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -153,7 +153,7 @@ class ConfigurationList extends React.Component<Props, State> {
           isDisabledChecker={this.isConfigurationDisabled}
           isSitewide={this.props.isSitewide}
           onClose={this.handleQuit}
-          onDelete={this.handleContentDelete}
+          onDelete={this.handleConfigurationDeletion}
           onCreate={this.handleConfigurationCreation}
           onSelect={this.handleConfigurationOpen}
           path={this.props.editor.iframeWindow.location.pathname}
@@ -275,6 +275,51 @@ class ConfigurationList extends React.Component<Props, State> {
 
   private handleConfigurationCreation = () => {
     this.handleConfigurationOpen(this.getDefaultConfiguration())
+  }
+
+  private handleConfigurationDeletion = async (
+    configuration: ExtensionConfiguration
+  ) => {
+    const { editor, iframeRuntime, intl, template, treePath } = this.props
+
+    editor.setIsLoading(true)
+
+    const action = getIsDefaultContent(configuration) ? 'reset' : 'delete'
+
+    try {
+      await this.props.deleteContent({
+        variables: {
+          contentId: configuration.contentId,
+          pageContext: iframeRuntime.route.pageContext,
+          template,
+          treePath,
+        },
+      })
+
+      this.props.iframeRuntime.updateRuntime()
+
+      await this.refetchConfigurations()
+
+      editor.setIsLoading(false)
+
+      this.props.showToast({
+        horizontalPosition: 'right',
+        message: intl.formatMessage({
+          id: `admin/pages.editor.components.content.${action}.success`,
+        }),
+      })
+    } catch (e) {
+      editor.setIsLoading(false)
+
+      this.props.showToast({
+        horizontalPosition: 'right',
+        message: intl.formatMessage({
+          id: `admin/pages.editor.components.content.${action}.error`,
+        }),
+      })
+
+      console.error(e)
+    }
   }
 
   private handleConfigurationDiscard = () => {
@@ -413,51 +458,6 @@ class ConfigurationList extends React.Component<Props, State> {
 
         console.log(err)
       })
-    }
-  }
-
-  private handleContentDelete = async (
-    configuration: ExtensionConfiguration
-  ) => {
-    const { editor, iframeRuntime, intl, template, treePath } = this.props
-
-    editor.setIsLoading(true)
-
-    const action = getIsDefaultContent(configuration) ? 'reset' : 'delete'
-
-    try {
-      await this.props.deleteContent({
-        variables: {
-          contentId: configuration.contentId,
-          pageContext: iframeRuntime.route.pageContext,
-          template,
-          treePath,
-        },
-      })
-
-      this.props.iframeRuntime.updateRuntime()
-
-      await this.refetchConfigurations()
-
-      editor.setIsLoading(false)
-
-      this.props.showToast({
-        horizontalPosition: 'right',
-        message: intl.formatMessage({
-          id: `admin/pages.editor.components.content.${action}.success`,
-        }),
-      })
-    } catch (e) {
-      editor.setIsLoading(false)
-
-      this.props.showToast({
-        horizontalPosition: 'right',
-        message: intl.formatMessage({
-          id: `admin/pages.editor.components.content.${action}.error`,
-        }),
-      })
-
-      console.error(e)
     }
   }
 

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -161,9 +161,10 @@ class ConfigurationList extends React.Component<Props, State> {
       <ContentEditor
         componentTitle={this.componentTitle}
         condition={this.state.condition}
-        configuration={this.state.configuration}
         contentSchema={this.contentSchema}
+        data={this.state.formData}
         iframeRuntime={iframeRuntime}
+        isDefault={getIsDefaultContent(this.state.configuration)}
         isLoading={formMeta.isLoading && !modal.isOpen}
         isSitewide={this.props.isSitewide}
         label={label}

--- a/react/components/EditorContainer/Sidebar/FormMetaContext.tsx
+++ b/react/components/EditorContainer/Sidebar/FormMetaContext.tsx
@@ -3,17 +3,27 @@ import React, { Component, createContext, useContext } from 'react'
 import { FormMetaContext as FormMetaContextT } from './typings'
 
 const defaultExternalState: FormMetaContextT = {
+  addToI18nMapping: () => {
+    return
+  },
+  clearI18nMapping: () => {
+    return
+  },
+  getI18nMapping: () => {
+    return {}
+  },
+  getIsLoading: () => {
+    return false
+  },
   getWasModified: () => {
     return false
   },
-  isLoading: false,
   setWasModified: () => {
     return
   },
   toggleLoading: () => {
     return
   },
-  wasModified: false,
 }
 
 const FormMetaContext = createContext(defaultExternalState)
@@ -22,7 +32,11 @@ export const useFormMetaContext = () => useContext(FormMetaContext)
 
 export const FormMetaConsumer = FormMetaContext.Consumer
 
-type State = FormMetaContextT
+interface State extends FormMetaContextT {
+  i18nMapping: Record<string, string>
+  isLoading: boolean
+  wasModified: boolean
+}
 
 export class FormMetaProvider extends Component<{}, State> {
   constructor(props: {}) {
@@ -30,9 +44,16 @@ export class FormMetaProvider extends Component<{}, State> {
 
     this.state = {
       ...defaultExternalState,
+      addToI18nMapping: this.addToI18nMapping,
+      clearI18nMapping: this.clearI18nMapping,
+      getI18nMapping: this.getI18nMapping,
+      getIsLoading: this.getIsLoading,
       getWasModified: this.getWasModified,
+      i18nMapping: {},
+      isLoading: false,
       setWasModified: this.setWasModified,
       toggleLoading: this.toggleLoading,
+      wasModified: false,
     }
   }
 
@@ -44,9 +65,22 @@ export class FormMetaProvider extends Component<{}, State> {
     )
   }
 
-  private getWasModified: State['getWasModified'] = () => {
-    return this.state.wasModified
+  private addToI18nMapping: State['addToI18nMapping'] = newEntry => {
+    this.setState(prevState => ({
+      ...prevState,
+      i18nMapping: { ...prevState.i18nMapping, ...newEntry },
+    }))
   }
+
+  private clearI18nMapping: State['clearI18nMapping'] = () => {
+    this.setState({ i18nMapping: {} })
+  }
+
+  private getI18nMapping: State['getI18nMapping'] = () => this.state.i18nMapping
+
+  private getIsLoading: State['getIsLoading'] = () => this.state.isLoading
+
+  private getWasModified: State['getWasModified'] = () => this.state.wasModified
 
   private setWasModified: State['setWasModified'] = (newValue, callback) => {
     this.setState({ wasModified: newValue }, () => {

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -48,7 +48,7 @@ const Sidebar: React.FunctionComponent<Props> = ({
       >
         <div className="h-100 flex flex-column dark-gray">
           <Modal
-            isActionLoading={formMeta.isLoading}
+            isActionLoading={formMeta.getIsLoading()}
             isOpen={modal.isOpen}
             onClickAction={modal.actionHandler}
             onClickCancel={modal.cancelHandler}

--- a/react/components/EditorContainer/Sidebar/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/typings.d.ts
@@ -1,9 +1,11 @@
 export interface FormMetaContext {
-  getWasModified: () => FormMetaContext['wasModified']
-  isLoading: boolean
+  addToI18nMapping: (newEntry: Record<string, string>) => void
+  clearI18nMapping: () => void
+  getI18nMapping: () => Record<string, string>
+  getIsLoading: () => boolean
+  getWasModified: () => boolean
   setWasModified: (newValue: boolean, callback?: () => void) => void
   toggleLoading: (callback?: () => void) => void
-  wasModified: boolean
 }
 
 export interface ModalContext {
@@ -18,7 +20,7 @@ export interface ModalContext {
       actionHandler?: ModalContext['actionHandler']
       cancelHandler?: ModalContext['cancelHandler']
       closeCallbackHandler?: ModalContext['closeCallbackHandler']
-    },
+    }
   ) => void
 }
 

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -15,7 +15,6 @@ type Props = RenderContextProps &
 
 interface State {
   activeConditions: string[]
-  addMessages: MessagesAdder
   allMatches: boolean
   editMode: boolean
   editTreePath: string | null
@@ -46,9 +45,6 @@ class EditorProvider extends Component<Props, State> {
 
     this.state = {
       activeConditions: [],
-      addMessages: () => {
-        return
-      },
       allMatches: true,
       editMode: false,
       editTreePath: null,
@@ -66,8 +62,7 @@ class EditorProvider extends Component<Props, State> {
       window.__provideRuntime = async (
         runtime,
         messages,
-        shouldUpdateRuntime,
-        addMessages
+        shouldUpdateRuntime
       ) => {
         const { client } = this.props
         let formattedEditorMessages = {}
@@ -100,7 +95,6 @@ class EditorProvider extends Component<Props, State> {
 
         const newState = {
           ...this.state,
-          addMessages,
           iframeRuntime: runtime,
           ...(this.state.iframeRuntime
             ? {}
@@ -112,7 +106,9 @@ class EditorProvider extends Component<Props, State> {
           messages: newMessages,
         }
 
-        this.setState(newState)
+        await new Promise(resolve => {
+          this.setState(newState, resolve)
+        })
 
         if (
           this.state.iframeRuntime &&
@@ -312,7 +308,6 @@ class EditorProvider extends Component<Props, State> {
 
     const {
       activeConditions,
-      addMessages,
       allMatches,
       editMode,
       editTreePath,
@@ -328,7 +323,6 @@ class EditorProvider extends Component<Props, State> {
     const editor: EditorContext = {
       activeConditions,
       addCondition: this.handleAddCondition,
-      addMessages,
       allMatches,
       editExtensionPoint: this.editExtensionPoint,
       editMode,

--- a/react/components/form/BaseInput.tsx
+++ b/react/components/form/BaseInput.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { WidgetProps } from 'react-jsonschema-form'
 import { formatIOMessage } from 'vtex.native-types'
 import { Input } from 'vtex.styleguide'
 
-interface Props extends InjectedIntlProps, WidgetProps {
+import { CustomWidgetProps } from './typings'
+
+interface Props extends CustomWidgetProps, InjectedIntlProps {
   label: string
   max?: number
   min?: number
@@ -12,7 +13,7 @@ interface Props extends InjectedIntlProps, WidgetProps {
   type?: string
 }
 
-const BaseInput: React.FunctionComponent<WidgetProps & Props> = props => {
+const BaseInput: React.FunctionComponent<Props> = props => {
   const {
     autofocus,
     disabled,

--- a/react/components/form/Dropdown.tsx
+++ b/react/components/form/Dropdown.tsx
@@ -1,31 +1,20 @@
 import React from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { WidgetProps } from 'react-jsonschema-form'
 import { formatIOMessage } from 'vtex.native-types'
 import { Dropdown as StyleguideDropdown } from 'vtex.styleguide'
 
-interface Props {
-  label?: string
+import { CustomWidgetProps } from './typings'
+
+interface Props extends CustomWidgetProps, InjectedIntlProps {
   onClose?: () => void
   onOpen?: () => void
-  schema: {
-    disabled?: boolean
-  }
   options: {
     emptyValue: string
     enumOptions: Array<{ label: string }>
   }
 }
 
-type DropdownProps = Props & WidgetProps & InjectedIntlProps
-
-const getChangeHandler = (
-  onChange: (value?: string) => void,
-  emptyValue?: string
-) => ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) =>
-  onChange(!value ? emptyValue : value)
-
-const Dropdown: React.FunctionComponent<DropdownProps> = ({
+const Dropdown: React.FunctionComponent<Props> = ({
   autofocus,
   disabled,
   id,
@@ -39,30 +28,41 @@ const Dropdown: React.FunctionComponent<DropdownProps> = ({
   readonly,
   schema,
   value,
-}) => (
-  <StyleguideDropdown
-    autoFocus={autofocus}
-    disabled={disabled || (schema && schema.disabled)}
-    id={id}
-    label={formatIOMessage({ id: label, intl })}
-    onChange={onChange && getChangeHandler(onChange, options.emptyValue)}
-    onClose={onClose}
-    onOpen={onOpen}
-    options={options.enumOptions.map(option => ({
-      ...option,
-      label: formatIOMessage({ id: `${option.label}`, intl }),
-    }))}
-    placeholder={placeholder ? formatIOMessage({ id: placeholder, intl }) : ''}
-    readOnly={readonly}
-    value={value || ''}
-  />
-)
+}) => {
+  const handleChange = React.useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) =>
+      onChange(!value ? options.emptyValue : value),
+    []
+  )
+
+  return (
+    <StyleguideDropdown
+      autoFocus={autofocus}
+      disabled={disabled || (schema && schema.disabled)}
+      id={id}
+      label={formatIOMessage({ id: label, intl })}
+      onChange={handleChange}
+      onClose={onClose}
+      onOpen={onOpen}
+      options={options.enumOptions.map(option => ({
+        ...option,
+        label: formatIOMessage({ id: `${option.label}`, intl }),
+      }))}
+      placeholder={
+        placeholder ? formatIOMessage({ id: placeholder, intl }) : ''
+      }
+      readOnly={readonly}
+      value={value}
+    />
+  )
+}
 
 Dropdown.defaultProps = {
   autofocus: false,
   disabled: false,
   readonly: false,
   required: false,
+  value: '',
 }
 
 export default injectIntl(Dropdown)

--- a/react/components/form/IOMessage.tsx
+++ b/react/components/form/IOMessage.tsx
@@ -1,30 +1,58 @@
+import debounce from 'lodash.debounce'
 import React from 'react'
-import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { WidgetProps } from 'react-jsonschema-form'
+import { generate as generateUuid } from 'short-uuid'
 
+import { translateMessage } from '../../utils/components'
 import { useFormMetaContext } from '../EditorContainer/Sidebar/FormMetaContext'
-import { useEditorContext } from '../EditorContext'
 
 import BaseInput from './BaseInput'
+import { CustomWidgetProps } from './typings'
 
-type Props = InjectedIntlProps & WidgetProps
+const IOMessage: React.FunctionComponent<CustomWidgetProps> = props => {
+  const {
+    addToI18nMapping,
+    getI18nMapping,
+    getWasModified,
+    setWasModified,
+  } = useFormMetaContext()
 
-const IOMessage: React.FunctionComponent<Props> = props => {
-  const { addMessages, messages } = useEditorContext()
-  const { setWasModified, wasModified } = useFormMetaContext()
+  const i18nKey = props.value
 
-  const [i18nKey] = React.useState(props.value)
-
-  const message = messages[i18nKey]
-
-  const initialValue = message || (message === '' ? '' : i18nKey)
+  const initialValue = React.useMemo(
+    () =>
+      translateMessage({
+        dictionary: props.formContext.messages,
+        id: i18nKey,
+      }),
+    []
+  )
 
   const [value, setValue] = React.useState(initialValue)
 
+  const mappedI18nKey = React.useMemo(generateUuid, [])
+
+  const updateIframeValue = React.useMemo(
+    () =>
+      debounce((newValue: string) => {
+        const i18nMapping = getI18nMapping()
+
+        if (!i18nMapping[i18nKey]) {
+          addToI18nMapping({ [i18nKey]: mappedI18nKey })
+
+          props.onChange(mappedI18nKey)
+        }
+
+        props.formContext.addMessages({
+          [mappedI18nKey]: newValue,
+        })
+      }, 200),
+    []
+  )
+
   const handleChange = React.useCallback((newValue: string) => {
-    addMessages({
-      [i18nKey]: newValue,
-    })
+    const wasModified = getWasModified()
+
+    updateIframeValue(newValue)
 
     if (!wasModified) {
       setWasModified(true)
@@ -36,4 +64,4 @@ const IOMessage: React.FunctionComponent<Props> = props => {
   return <BaseInput {...props} onChange={handleChange} value={value} />
 }
 
-export default injectIntl(IOMessage)
+export default IOMessage

--- a/react/components/form/IOMessage.tsx
+++ b/react/components/form/IOMessage.tsx
@@ -36,7 +36,7 @@ const IOMessage: React.FunctionComponent<CustomWidgetProps> = props => {
       debounce((newValue: string) => {
         const i18nMapping = getI18nMapping()
 
-        if (!i18nMapping[i18nKey]) {
+        if (i18nMapping[i18nKey] === undefined) {
           addToI18nMapping({ [i18nKey]: mappedI18nKey })
 
           props.onChange(mappedI18nKey)

--- a/react/components/form/TextArea.tsx
+++ b/react/components/form/TextArea.tsx
@@ -1,15 +1,11 @@
 import React from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { WidgetProps } from 'react-jsonschema-form'
 import { formatIOMessage } from 'vtex.native-types'
 import { Textarea } from 'vtex.styleguide'
 
-interface Props extends InjectedIntlProps, WidgetProps {
-  autofocus: boolean
-  label: string
-  rawErrors?: string[]
-  onChange(val: string): void
-}
+import { CustomWidgetProps } from './typings'
+
+type Props = CustomWidgetProps & InjectedIntlProps
 
 const TextArea: React.FunctionComponent<Props> = ({
   autofocus,

--- a/react/components/form/Toggle.tsx
+++ b/react/components/form/Toggle.tsx
@@ -1,23 +1,13 @@
 import React from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { WidgetProps } from 'react-jsonschema-form'
 import { formatIOMessage } from 'vtex.native-types'
 import { Toggle as StyleguideToggle } from 'vtex.styleguide'
 
-interface Props extends InjectedIntlProps {
-  label?: string
-  autofocus?: boolean
-  disabled?: boolean
-  id?: string
-  onChange?: React.EventHandler<React.ChangeEvent>
-  readonly?: boolean
-  schema: {
-    disabled?: boolean
-  }
-  value?: boolean
-}
+import { CustomWidgetProps } from './typings'
 
-const Toggle: React.FunctionComponent<WidgetProps & Props> = ({
+type Props = CustomWidgetProps & InjectedIntlProps
+
+const Toggle: React.FunctionComponent<Props> = ({
   autofocus,
   disabled,
   id,

--- a/react/components/form/typings.d.ts
+++ b/react/components/form/typings.d.ts
@@ -1,0 +1,13 @@
+import { WidgetProps } from 'react-jsonschema-form'
+
+export interface CustomWidgetProps extends WidgetProps {
+  formContext: {
+    addMessages: RenderContext['addMessages']
+    messages: RenderContext['messages']
+    isLayout: boolean
+  }
+  rawErrors?: string[]
+  schema: WidgetProps['schema'] & {
+    disabled?: boolean
+  }
+}

--- a/react/package.json
+++ b/react/package.json
@@ -18,6 +18,7 @@
     "react-select": "^1.2.1",
     "react-sortable-hoc": "^0.8.3",
     "react-spring": "^8.0.18",
+    "short-uuid": "^3.1.1",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,5 +1,7 @@
 import { Component, ReactElement } from 'react'
+
 import { State as HighlightOverlayState } from '../HighlightOverlay'
+
 declare global {
   declare module '*.graphql' {
     import { DocumentNode } from 'graphql'
@@ -93,6 +95,7 @@ declare global {
 
   interface RenderContext {
     account: RenderRuntime['account']
+    addMessages: (newMessages: RenderContext['messages']) => void
     components: RenderRuntime['components']
     culture: RenderRuntime['culture']
     device: ConfigurationDevice
@@ -101,6 +104,7 @@ declare global {
     fetchComponent: (component: string) => Promise<void>
     getSettings: (app: string) => any
     history: RuntimeHistory | null
+    messages: RenderRuntime['messages']
     navigate: (options: NavigateOptions) => boolean
     onPageChanged: (location: Location) => void
     page: RenderRuntime['page']
@@ -112,7 +116,7 @@ declare global {
     renderMajor: RenderRuntime['renderMajor']
     setDevice: (device: ConfigurationDevice) => void
     updateComponentAssets: (availableComponents: Components) => void
-    updateExtension: (name: string, extension: Extension) => void
+    updateExtension: (name: string, extension: Extension) => Promise<void>
     updateRuntime: (options?: PageContextOptions) => Promise<void>
     workspace: RenderRuntime['workspace']
   }
@@ -141,7 +145,6 @@ declare global {
 
   interface EditorContext extends EditorConditionSection {
     allMatches: boolean
-    addMessages: MessagesAdder
     editMode: boolean
     editTreePath: string | null
     iframeWindow: Window
@@ -268,15 +271,12 @@ declare global {
 
   type UISchema = any
 
-  type MessagesAdder = (messages: RenderRuntime['messages']) => void
-
   interface Window {
     __provideRuntime?: (
       runtime: RenderContext,
       messages: Record<string, string>,
-      shouldUpdateRuntime: boolean,
-      addMessages: MessagesAdder
-    ) => void
+      shouldUpdateRuntime: boolean
+    ) => Promise<void>
   }
 
   interface AdminContext {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -95,7 +95,7 @@ declare global {
 
   interface RenderContext {
     account: RenderRuntime['account']
-    addMessages: (newMessages: RenderContext['messages']) => void
+    addMessages: (newMessages: RenderContext['messages']) => Promise<void>
     components: RenderRuntime['components']
     culture: RenderRuntime['culture']
     device: ConfigurationDevice

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -155,7 +155,9 @@ export const getSchemaPropsOrContent = ({
               dictionary: messages,
               id:
                 propsOrContent[
-                  (i18nMapping && i18nMapping[currKey]) || currKey
+                  i18nMapping && i18nMapping[currKey] !== undefined
+                    ? i18nMapping[currKey]
+                    : currKey
                 ],
             })
           : propsOrContent[currKey],

--- a/react/utils/components/typings.d.ts
+++ b/react/utils/components/typings.d.ts
@@ -1,5 +1,8 @@
 import { JSONSchema6 } from 'json-schema'
+import { InjectedIntl } from 'react-intl'
 import { RenderComponent } from 'vtex.render-runtime'
+
+import { FormMetaContext } from '../../components/EditorContainer/Sidebar/typings'
 
 type PropsOrContent = Record<string, any>
 
@@ -11,19 +14,25 @@ export interface GetComponentSchemaParams {
 }
 
 export interface GetSchemaPropsOrContentParams {
+  i18nMapping?: FormMetaContext['i18nMapping']
   isContent?: boolean
-  messages: EditorContext['messages']
+  messages?: RenderContext['messages']
   properties?: Record<string, JSONSchema6Definition>
-  propsOrContent: Record<>
+  propsOrContent?: Record<string, any>
 }
 
 export interface GetSchemaPropsOrContentFromRuntimeParams {
   component: RenderComponent<any, any> | null
   contentSchema?: JSONSchema6
   isContent?: boolean
-  messages: EditorContext['messages']
+  messages?: RenderContext['messages']
   propsOrContent: PropsOrContent
   runtime: RenderContext
+}
+
+export interface TranslateMessageParams {
+  dictionary: Record<string, string>
+  id?: string
 }
 
 export interface UpdateExtensionFromFormParams {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1206,6 +1206,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+any-base@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
+  integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -5533,6 +5538,14 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+short-uuid@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/short-uuid/-/short-uuid-3.1.1.tgz#3ff427074b5fa7822c3793994d18a7a82e2f73a4"
+  integrity sha512-7dI69xtJYpTIbg44R6JSgrbDtZFuZ9vAwwmnF/L0PinykbFrhQ7V8omKsQcVw1TP0nYJ7uQp1PN6/aVMkzQFGQ==
+  dependencies:
+    any-base "^1.1.0"
+    uuid "^3.3.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- When deleting a configuration, keep the loader until the configuration has been deleted;
- Bug fix: inconsistent content edition caused by desynchronized Runtimes;
- Bug fix: configuration list not being updated after creating/deleting configurations.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Mainly content edition issues.

#### How should this be manually tested?
Workspace: https://i18n--storecomponents.myvtex.com/admin/cms/storefront.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue).

#### External dependencies
- https://github.com/vtex-apps/render-runtime/pull/296.