### PR TITLE
Add a 'PWA App Settings' subsection to show what really needs to be f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `PWA App Settings` subsection so users can clearly see what really needs to be filled in the `Advanced Settings` form.
+
 ## [3.8.2] - 2019-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `PWA App Settings` subsection so users can clearly see what really needs to be filled in the `Advanced Settings` form.
+- `Other PWA settings` subsection so users can clearly see what really needs to be filled in the `Advanced Settings` form.
 
 ## [3.8.2] - 2019-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.9.0] - 2019-05-22
+
 ### Added
 
 - `Other PWA settings` subsection so users can clearly see what really needs to be filled in the `Advanced Settings` form.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,6 @@
     {
       "name": "vtex.file-manager:saveFileAsync"
     }
-  ]
+  ],
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -151,6 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "admin/pages.editor.store.settings.error.title",
   "admin/pages.editor.store.settings.error": "admin/pages.editor.store.settings.error",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "admin/pages.editor.store.settings.pwa.android-logo-icon",
+  "admin/pages.editor.store.settings.pwa.app-settings": "admin/pages.editor.store.settings.pwa.app-settings",
   "admin/pages.editor.store.settings.pwa.background_color": "admin/pages.editor.store.settings.pwa.background_color",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "admin/pages.editor.store.settings.pwa.disable-prompt",
   "admin/pages.editor.store.settings.pwa.display.browser": "admin/pages.editor.store.settings.pwa.display.browser",

--- a/messages/en.json
+++ b/messages/en.json
@@ -151,7 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Something went wrong",
   "admin/pages.editor.store.settings.error": "Couldn't load store settings.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Android Logo Icon (512x512)",
-  "admin/pages.editor.store.settings.pwa.app-settings": "PWA App settings",
+  "admin/pages.editor.store.settings.pwa.app-settings": "Other PWA settings",
   "admin/pages.editor.store.settings.pwa.background_color": "Background color",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Add to Home Screen",
   "admin/pages.editor.store.settings.pwa.display.browser": "Browser",

--- a/messages/en.json
+++ b/messages/en.json
@@ -151,6 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Something went wrong",
   "admin/pages.editor.store.settings.error": "Couldn't load store settings.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Android Logo Icon (512x512)",
+  "admin/pages.editor.store.settings.pwa.app-settings": "PWA App settings",
   "admin/pages.editor.store.settings.pwa.background_color": "Background color",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Add to Home Screen",
   "admin/pages.editor.store.settings.pwa.display.browser": "Browser",

--- a/messages/es.json
+++ b/messages/es.json
@@ -151,6 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Algo salió mal",
   "admin/pages.editor.store.settings.error": "No se pudo cargar la configuración de la tienda.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Icono de Logotipo Android (512x512)",
+  "admin/pages.editor.store.settings.pwa.app-settings": "Configuración de la aplicación PWA",
   "admin/pages.editor.store.settings.pwa.background_color": "Color de fondo",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Añadir a la pantalla principal",
   "admin/pages.editor.store.settings.pwa.display.browser": "Navegador",

--- a/messages/es.json
+++ b/messages/es.json
@@ -151,7 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Algo salió mal",
   "admin/pages.editor.store.settings.error": "No se pudo cargar la configuración de la tienda.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Icono de Logotipo Android (512x512)",
-  "admin/pages.editor.store.settings.pwa.app-settings": "Configuración de la aplicación PWA",
+  "admin/pages.editor.store.settings.pwa.app-settings": "Otras configuraciones de PWA",
   "admin/pages.editor.store.settings.pwa.background_color": "Color de fondo",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Añadir a la pantalla principal",
   "admin/pages.editor.store.settings.pwa.display.browser": "Navegador",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -151,6 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Algo deu errado",
   "admin/pages.editor.store.settings.error": "Não foi possível carregar as informações da loja.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Ícone de Logo Android (512x512)",
+  "admin/pages.editor.store.settings.pwa.app-settings": "Configurações do aplicativo PWA",
   "admin/pages.editor.store.settings.pwa.background_color": "Cor de fundo",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Adicionar à tela inicial",
   "admin/pages.editor.store.settings.pwa.display.browser": "Navegador",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -151,7 +151,7 @@
   "admin/pages.editor.store.settings.error.title": "Algo deu errado",
   "admin/pages.editor.store.settings.error": "Não foi possível carregar as informações da loja.",
   "admin/pages.editor.store.settings.pwa.android-logo-icon": "Ícone de Logo Android (512x512)",
-  "admin/pages.editor.store.settings.pwa.app-settings": "Configurações do aplicativo PWA",
+  "admin/pages.editor.store.settings.pwa.app-settings": "Outras configurações do PWA",
   "admin/pages.editor.store.settings.pwa.background_color": "Cor de fundo",
   "admin/pages.editor.store.settings.pwa.disable-prompt": "Adicionar à tela inicial",
   "admin/pages.editor.store.settings.pwa.display.browser": "Navegador",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.6.2",
+  "version": "3.9.0",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
@@ -250,6 +250,18 @@ const PWAForm: React.FunctionComponent<Props> = ({
           </div>
         </div>
       )}
+      <div className="pv7">
+        <div className="w-100 bb b--muted-4" />
+      </div>
+      <div
+        className="pb3 link pointer c-muted-1"
+        onClick={() => setShowSpecific(!showSpecific)}
+      >
+        <span className="pr4">
+          <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
+        </span>
+        {showSpecific ? <IconCaretUp /> : <IconCaretDown />}
+      </div>
       {showSpecific && (
         <>
           <div className="pt4 w-100">
@@ -312,18 +324,6 @@ const PWAForm: React.FunctionComponent<Props> = ({
           </div>
         </>
       )}
-      <div className="pv7">
-        <div className="w-100 bb b--muted-4" />
-      </div>
-      <div
-        className="link pointer c-muted-1"
-        onClick={() => setShowSpecific(!showSpecific)}
-      >
-        <span className="pr4">
-          <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
-        </span>
-        {showSpecific ? <IconCaretUp /> : <IconCaretDown />}
-      </div>
       <div className="w-100 mt7 tr">
         <Button
           size="small"

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
@@ -250,22 +250,7 @@ const PWAForm: React.FunctionComponent<Props> = ({
           </div>
         </div>
       )}
-      {!showSpecific ? (
-        <>
-          <div className="pv7">
-            <div className="w-100 bb b--muted-4" />
-          </div>
-          <div
-            className="link pointer c-muted-1"
-            onClick={() => setShowSpecific(true)}
-          >
-            <span className="pr4">
-              <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
-            </span>
-            <IconCaretDown />
-          </div>
-        </>
-      ) : (
+      {showSpecific && (
         <>
           <div className="pt4 w-100">
             <Input
@@ -325,20 +310,20 @@ const PWAForm: React.FunctionComponent<Props> = ({
               }
             />
           </div>
-          <div className="pv7">
-            <div className="w-100 bb b--muted-4" />
-          </div>
-          <div
-            className="link pointer c-muted-1"
-            onClick={() => setShowSpecific(false)}
-          >
-            <span className="pr4">
-              <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
-            </span>
-            <IconCaretUp />
-          </div>
         </>
       )}
+      <div className="pv7">
+        <div className="w-100 bb b--muted-4" />
+      </div>
+      <div
+        className="link pointer c-muted-1"
+        onClick={() => setShowSpecific(!showSpecific)}
+      >
+        <span className="pr4">
+          <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
+        </span>
+        {showSpecific ? <IconCaretUp /> : <IconCaretDown />}
+      </div>
       <div className="w-100 mt7 tr">
         <Button
           size="small"

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/index.tsx
@@ -7,6 +7,8 @@ import {
   Button,
   ColorPicker,
   Dropdown,
+  IconCaretDown,
+  IconCaretUp,
   Input,
   ToastContext,
   Toggle,
@@ -65,6 +67,7 @@ const PWAForm: React.FunctionComponent<Props> = ({
     pwaManifest.background_color,
   ])
   const [submitting, setSubmitting] = useState(false)
+  const [showSpecific, setShowSpecific] = useState(false)
   const { showToast } = useContext(ToastContext)
 
   const [splash = null] = splashes || []
@@ -201,52 +204,7 @@ const PWAForm: React.FunctionComponent<Props> = ({
           </div>
         </div>
       </div>
-      <div className="pt2 w-100">
-        <Input
-          disabled={submitting}
-          size="small"
-          label={intl.formatMessage(messages.startUrl)}
-          value={manifest.start_url}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setManifest({ ...manifest, start_url: e.target.value })
-          }
-        />
-      </div>
-      <div className="pt4 w-100">
-        <Dropdown
-          disabled={submitting}
-          value={manifest.orientation}
-          label={intl.formatMessage(messages.screenOrientation)}
-          options={ORIENTATION_OPTIONS.map(option => ({
-            ...option,
-            label: intl.formatMessage({ id: option.label }),
-          }))}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            setManifest({
-              ...manifest,
-              orientation: e.target.value,
-            })
-          }
-        />
-      </div>
-      <div className="pt4">
-        <Dropdown
-          disabled={submitting}
-          value={manifest.display}
-          label={intl.formatMessage(messages.pwaDisplay)}
-          options={DISPLAY_OPTIONS.map(option => ({
-            ...option,
-            label: intl.formatMessage({ id: option.label }),
-          }))}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            setManifest({
-              ...manifest,
-              display: e.target.value,
-            })
-          }
-        />
-      </div>
-      <div className="flex flex-column items-center justify-center pt5">
+      <div className="flex flex-column items-center justify-center">
         <div className="w-100 pt4">
           <ImageUploader
             disabled={submitting}
@@ -292,16 +250,95 @@ const PWAForm: React.FunctionComponent<Props> = ({
           </div>
         </div>
       )}
-      <div className="pt6">
-        <Toggle
-          label={intl.formatMessage(messages.disablePrompt)}
-          checked={!settings.disablePrompt}
-          disabled={submitting}
-          onChange={() =>
-            setSettings({ ...settings, disablePrompt: !settings.disablePrompt })
-          }
-        />
-      </div>
+      {!showSpecific ? (
+        <>
+          <div className="pv7">
+            <div className="w-100 bb b--muted-4" />
+          </div>
+          <div
+            className="link pointer c-muted-1"
+            onClick={() => setShowSpecific(true)}
+          >
+            <span className="pr4">
+              <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
+            </span>
+            <IconCaretDown />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="pt4 w-100">
+            <Input
+              disabled={submitting}
+              size="small"
+              label={intl.formatMessage(messages.startUrl)}
+              value={manifest.start_url}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setManifest({ ...manifest, start_url: e.target.value })
+              }
+            />
+          </div>
+          <div className="pt4 w-100">
+            <Dropdown
+              disabled={submitting}
+              value={manifest.orientation}
+              label={intl.formatMessage(messages.screenOrientation)}
+              options={ORIENTATION_OPTIONS.map(option => ({
+                ...option,
+                label: intl.formatMessage({ id: option.label }),
+              }))}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setManifest({
+                  ...manifest,
+                  orientation: e.target.value,
+                })
+              }
+            />
+          </div>
+          <div className="pt4">
+            <Dropdown
+              disabled={submitting}
+              value={manifest.display}
+              label={intl.formatMessage(messages.pwaDisplay)}
+              options={DISPLAY_OPTIONS.map(option => ({
+                ...option,
+                label: intl.formatMessage({ id: option.label }),
+              }))}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setManifest({
+                  ...manifest,
+                  display: e.target.value,
+                })
+              }
+            />
+          </div>
+          <div className="pt6">
+            <Toggle
+              label={intl.formatMessage(messages.disablePrompt)}
+              checked={!settings.disablePrompt}
+              disabled={submitting}
+              onChange={() =>
+                setSettings({
+                  ...settings,
+                  disablePrompt: !settings.disablePrompt,
+                })
+              }
+            />
+          </div>
+          <div className="pv7">
+            <div className="w-100 bb b--muted-4" />
+          </div>
+          <div
+            className="link pointer c-muted-1"
+            onClick={() => setShowSpecific(false)}
+          >
+            <span className="pr4">
+              <FormattedMessage id="admin/pages.editor.store.settings.pwa.app-settings" />
+            </span>
+            <IconCaretUp />
+          </div>
+        </>
+      )}
       <div className="w-100 mt7 tr">
         <Button
           size="small"


### PR DESCRIPTION
…illed in the Advanced Settings form

#### What is the purpose of this pull request?

As the title says, we want to be clear about what fields need to be filled by the user and what fields are automatically filled by us and they don't need to worry about.

#### What problem is this solving?

Too much tech information in a form.

#### How should this be manually tested?

[Access the workspace](https://pwa--storecomponents.myvtex.com/admin/cms/storefront) and see _CMS > Storefront > Store Settings > Advanced Settings_.

#### Screenshots or example usage

![PWA App Settings](https://user-images.githubusercontent.com/15948386/58194042-d2812e80-7c9a-11e9-9ca0-b632bb078b57.gif)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
