### PR TITLE
Blocks have names too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.10.0] - 2019-05-23
+
 ### Added
 
 - Support for `title` that comes from block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `title` that comes from block.
+
+### Changed
+
+- `title` from block is also considered when deciding whether to show or hide the extension on the Sidebar.
+
 ## [3.9.1] - 2019-05-23
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
@@ -1,8 +1,9 @@
 import classnames from 'classnames'
 import React from 'react'
-import { FormattedMessage } from 'react-intl'
+import { InjectedIntlProps, injectIntl } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
 
-interface Props {
+interface Props extends InjectedIntlProps {
   hasSubItems?: boolean
   isSortable?: boolean
   isChild?: boolean
@@ -15,6 +16,7 @@ interface Props {
 
 const Item: React.FunctionComponent<Props> = ({
   hasSubItems,
+  intl,
   isSortable,
   isChild,
   onEdit,
@@ -48,15 +50,11 @@ const Item: React.FunctionComponent<Props> = ({
         ...(!hasSubItems || isSortable ? { marginLeft: 1 } : null),
       }}
     >
-      <FormattedMessage id={title}>
-        {text => (
-          <span className={`f6 fw4 track-1 ${isChild ? 'pl7' : 'pl2'}`}>
-            {text}
-          </span>
-        )}
-      </FormattedMessage>
+      <span className={`f6 fw4 track-1 ${isChild ? 'pl7' : 'pl2'}`}>
+        {formatIOMessage({ id: title, intl })}
+      </span>
     </div>
   )
 }
 
-export default Item
+export default injectIntl(Item)

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -55,12 +55,13 @@ export function getComponents(
       const schema = getComponentSchema(treePath)
       const componentName = getComponentName(treePath)
       const hasTitleInSchema = has('title', schema)
+      const hasTitle = hasTitleInSchema || has('title', extensions[treePath])
 
       if (schema && !hasTitleInSchema) {
         console.warn(generateWarningMessage(componentName))
       }
 
-      return isSamePage(page, treePath) && !!schema && hasTitleInSchema
+      return isSamePage(page, treePath) && !!schema && hasTitle
     })
     .sort((treePathA, treePathB) => {
       const parentPathA = `${treePathA.split('/')[0]}/${

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -111,7 +111,7 @@ export function getComponents(
       return treePathA > treePathB ? 1 : -1
     })
     .map<SidebarComponent>(treePath => ({
-      name: getComponentSchema(treePath).title!,
+      name: extensions[treePath].title || getComponentSchema(treePath).title!,
       treePath,
     }))
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -31,6 +31,7 @@ declare global {
     implements: string[]
     props: object
     shouldRender?: boolean
+    title?: string
   }
 
   interface Extensions {

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -117,6 +117,7 @@ export const getExtension = (
     implements: extensionImplements = [],
     props = {},
     shouldRender = false,
+    title = '',
   } = extensions[editTreePath!] || {}
 
   return {
@@ -132,7 +133,7 @@ export const getExtension = (
     implements: extensionImplements,
     props: props || {},
     shouldRender,
-    title: '',
+    title,
   }
 }
 

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -132,6 +132,7 @@ export const getExtension = (
     implements: extensionImplements,
     props: props || {},
     shouldRender,
+    title: '',
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow user to put the `title` key in their `blocks.json`.

#### What problem is this solving?
Storefront with user defined names for better organizarion.

#### How should this be manually tested?
[Workspace](https://blockswithnames--storecomponents.myvtexdev.com/admin/cms/storefront)

#### Screenshots or example usage
<img width="289" alt="Screen Shot 2019-05-23 at 11 48 05" src="https://user-images.githubusercontent.com/10400340/58262442-a627e980-7d50-11e9-8347-bdbda6729dac.png">

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Related PRs
| Project        | PR                     |
| ------------- |:-------------:|
| `builder-hub` | [https://github.com/vtex/builder-hub/pull/566](https://github.com/vtex/builder-hub/pull/566) |
| `pages-graphql`      |  [https://github.com/vtex/pages-graphql/pull/206](https://github.com/vtex/pages-graphql/pull/206)   |
