### PR TITLE
Fix - Unidentified page contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When the page context can't be identified, set the configuration scope as "this template" and display a toast with a brief explanation.
+
+### Fixed
+
+- Page context evaluation logic in configuration cards' tags.
+
 ## [3.10.0] - 2019-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.10.1] - 2019-05-23
+
 ### Changed
 
 - When the page context can't be identified, set the configuration scope as "this template" and display a toast with a brief explanation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/messages/context.json
+++ b/messages/context.json
@@ -123,6 +123,7 @@
   "admin/pages.editor.components.condition.scope.sitewide": "admin/pages.editor.components.condition.scope.sitewide",
   "admin/pages.editor.components.condition.scope.template": "admin/pages.editor.components.condition.scope.template",
   "admin/pages.editor.components.condition.scope.title": "admin/pages.editor.components.condition.scope.title",
+  "admin/pages.editor.components.condition.toast.error.page-context": "admin/pages.editor.components.condition.toast.error.page-context",
   "admin/pages.editor.components.condition.title": "admin/pages.editor.components.condition.title",
   "admin/pages.editor.components.configurations.button.create": "admin/pages.editor.components.configurations.button.create",
   "admin/pages.editor.components.configurations.defaultTitle": "admin/pages.editor.components.configurations.defaultTitle",

--- a/messages/en.json
+++ b/messages/en.json
@@ -123,6 +123,7 @@
   "admin/pages.editor.components.condition.scope.sitewide": "the entire site",
   "admin/pages.editor.components.condition.scope.template": "this template",
   "admin/pages.editor.components.condition.scope.title": "Apply to",
+  "admin/pages.editor.components.condition.toast.error.page-context": "Could not identify {entity}. The configuration will be set to \"{template}\".",
   "admin/pages.editor.components.condition.title": "Visibility",
   "admin/pages.editor.components.configurations.button.create": "Add content",
   "admin/pages.editor.components.configurations.defaultTitle": "Untitled",

--- a/messages/es.json
+++ b/messages/es.json
@@ -123,6 +123,7 @@
   "admin/pages.editor.components.condition.scope.sitewide": "todo el sitio",
   "admin/pages.editor.components.condition.scope.template": "este template",
   "admin/pages.editor.components.condition.scope.title": "Aplicar para",
+  "admin/pages.editor.components.condition.toast.error.page-context": "No se pudo identificar {entity}. La configuración será definida a \"{template}\".",
   "admin/pages.editor.components.condition.title": "Visibilidad",
   "admin/pages.editor.components.configurations.button.create": "Añadir contenido",
   "admin/pages.editor.components.configurations.defaultTitle": "Sin título",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -123,6 +123,7 @@
   "admin/pages.editor.components.condition.scope.sitewide": "todo o site",
   "admin/pages.editor.components.condition.scope.template": "este template",
   "admin/pages.editor.components.condition.scope.title": "Aplicar para",
+  "admin/pages.editor.components.condition.toast.error.page-context": "Não foi possível identificar {entity}. A configuração será definida para \"{template}\".",
   "admin/pages.editor.components.condition.title": "Visibilidade",
   "admin/pages.editor.components.configurations.button.create": "Adicionar conteúdo",
   "admin/pages.editor.components.configurations.defaultTitle": "Sem título",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.9.0",
+  "version": "3.10.1",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/ScopeSelector/index.tsx
@@ -5,16 +5,18 @@ import { RadioGroup } from 'vtex.styleguide'
 import { getScopeStandardOptions } from './utils'
 
 interface CustomProps {
+  isDisabled: boolean
+  isSitewide: boolean
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   pageContext: PageContext
   scope: ConfigurationScope
-  isSitewide: boolean
 }
 
 type Props = CustomProps & InjectedIntlProps
 
 const ScopeSelector: React.FunctionComponent<Props> = ({
   intl,
+  isDisabled,
   isSitewide,
   onChange,
   pageContext,
@@ -42,7 +44,7 @@ const ScopeSelector: React.FunctionComponent<Props> = ({
         {message => <div className="mb5">{message}</div>}
       </FormattedMessage>
       <RadioGroup
-        disabled={isSitewide}
+        disabled={isDisabled}
         name="scopes"
         onChange={onChange}
         options={options}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/ContentEditor/ConditionControls/index.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, PureComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import { formatStatements } from '../../../../../../utils/conditions'
+import { isUnidentifiedPageContext } from '../../utils'
 
 import Scheduler from './Scheduler'
 import ScopeSelector from './ScopeSelector'
@@ -18,6 +19,9 @@ interface Props {
 }
 
 class ConditionControls extends PureComponent<Props> {
+  private isScopeDisabled =
+    this.props.isSitewide || isUnidentifiedPageContext(this.props.pageContext)
+
   public render() {
     const { condition, isSitewide, pageContext } = this.props
 
@@ -39,6 +43,7 @@ class ConditionControls extends PureComponent<Props> {
 
         <div className="mv7 ph5">
           <ScopeSelector
+            isDisabled={this.isScopeDisabled}
             isSitewide={isSitewide}
             onChange={this.handleScopeChange}
             pageContext={pageContext}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/index.tsx
@@ -113,12 +113,12 @@ const Card = ({
           bgColor={isDisabled ? 'transparent' : 'light-gray'}
           borderColor="mid-gray"
           hasBorder={isDisabled}
-          text={getTextFromContext(
+          text={getTextFromContext({
+            context: configuration.condition.pageContext,
             intl,
             isSitewide,
             path,
-            configuration.condition.pageContext
-          )}
+          })}
           textColor="mid-gray"
         />
       </div>

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/typings.d.ts
@@ -1,0 +1,8 @@
+import { InjectedIntl } from 'react-intl'
+
+export interface GetTextFromContextArgs {
+  context: PageContext
+  intl: InjectedIntl
+  isSitewide: boolean
+  path: string
+}

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/List/Card/utils.ts
@@ -1,18 +1,18 @@
-import { InjectedIntl } from 'react-intl'
+import { GetTextFromContextArgs } from './typings'
 
-export const getTextFromContext = (
-  intl: InjectedIntl,
-  isSitewide: boolean,
-  path: string,
-  pageContext: PageContext
-) => {
+export const getTextFromContext = ({
+  context,
+  isSitewide,
+  intl,
+  path,
+}: GetTextFromContextArgs) => {
   if (isSitewide) {
     return intl.formatMessage({
       id: 'admin/pages.editor.configuration.tag.sitewide',
     })
   }
 
-  if (pageContext.id === '*' && pageContext.type === '*') {
+  if (context.id === '*') {
     return intl.formatMessage({
       id: 'admin/pages.editor.configuration.tag.template',
     })
@@ -20,8 +20,8 @@ export const getTextFromContext = (
 
   return intl.formatMessage(
     {
-      id: `admin/pages.editor.configuration.tag.${pageContext.type}`,
+      id: `admin/pages.editor.configuration.tag.${context.type}`,
     },
-    { id: pageContext.type === 'route' ? path : pageContext.id }
+    { id: context.type === 'route' ? path : context.id }
   )
 }

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -1,5 +1,4 @@
 import { JSONSchema6 } from 'json-schema'
-import debounce from 'lodash.debounce'
 import throttle from 'lodash.throttle'
 import { clone, Dictionary, equals, isEmpty, path, pickBy } from 'ramda'
 import React from 'react'
@@ -29,6 +28,7 @@ import { getIsDefaultContent } from '../utils'
 import { NEW_CONFIGURATION_ID } from './consts'
 import ContentEditor from './ContentEditor'
 import List from './List'
+import { isUnidentifiedPageContext } from './utils'
 
 interface Props {
   deleteContent: DeleteContentMutationFn
@@ -190,18 +190,27 @@ class ConfigurationList extends React.Component<Props, State> {
     )
   }
 
-  private getDefaultCondition = () => {
+  private getDefaultCondition = (): ExtensionConfiguration['condition'] => {
     const { iframeRuntime, isSitewide } = this.props
+
+    const iframePageContext = iframeRuntime.route.pageContext
+
+    const pageContext: ExtensionConfiguration['condition']['pageContext'] = isSitewide
+      ? {
+          id: '*',
+          type: '*',
+        }
+      : {
+          id: isUnidentifiedPageContext(iframePageContext)
+            ? '*'
+            : iframePageContext.id,
+          type: iframePageContext.type,
+        }
 
     return {
       allMatches: true,
       id: '',
-      pageContext: isSitewide
-        ? ({
-            id: '*',
-            type: '*',
-          } as ExtensionConfiguration['condition']['pageContext'])
-        : iframeRuntime.route.pageContext,
+      pageContext,
       statements: [],
     }
   }

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -53,7 +53,7 @@ interface State {
   newLabel?: string
 }
 
-defineMessages({
+const messages = defineMessages({
   deleteError: {
     defaultMessage: 'Something went wrong.',
     id: 'admin/pages.editor.components.content.delete.error',
@@ -61,6 +61,11 @@ defineMessages({
   deleteSuccess: {
     defaultMessage: 'Content deleted.',
     id: 'admin/pages.editor.components.content.delete.success',
+  },
+  pageContextError: {
+    defaultMessage:
+      'Could not identify {entity}. The configuration will be set to "{template}".',
+    id: 'admin/pages.editor.components.condition.toast.error.page-context',
   },
   resetError: {
     defaultMessage: 'Error resetting content.',
@@ -358,7 +363,7 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleConfigurationOpen = async (
     newConfiguration: ExtensionConfiguration
   ) => {
-    const { editor, iframeRuntime } = this.props
+    const { editor, iframeRuntime, intl, showToast } = this.props
 
     const baseContent =
       newConfiguration.contentId !== NEW_CONFIGURATION_ID
@@ -383,6 +388,29 @@ class ConfigurationList extends React.Component<Props, State> {
       },
       () => {
         editor.setIsLoading(false)
+
+        const { pageContext } = this.state.condition
+
+        if (isUnidentifiedPageContext(pageContext)) {
+          showToast({
+            horizontalPosition: 'right',
+            message: intl.formatMessage(
+              {
+                id: messages.pageContextError.id,
+              },
+              {
+                entity: intl.formatMessage({
+                  id: `admin/pages.editor.components.condition.scope.entity.${
+                    pageContext.type
+                  }`,
+                }),
+                template: intl.formatMessage({
+                  id: 'admin/pages.editor.components.condition.scope.template',
+                }),
+              }
+            ),
+          })
+        }
       }
     )
   }

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/utils.ts
@@ -1,0 +1,3 @@
+export const isUnidentifiedPageContext = (
+  pageContext: RenderRuntime['route']['pageContext']
+) => pageContext.type !== '*' && pageContext.id === '*'


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- When the page context can't be identified, set the configuration scope as "this template" and display a toast with a brief explanation;
- Fix the page context evaluation logic in configuration cards' tags.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Issues with unidentified page contexts.

#### How should this be manually tested?
Workspace: https://fixunidentifiedpagecontexts--storecomponents.myvtex.com/admin/cms/storefront/thisbranddoesnotexist/b.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8486092/58277923-3544f980-7d71-11e9-8558-422f98bbdfda.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)