### PR TITLE
Fix: Keep editor state when previewing website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.10.4] - 2019-05-28
+
 ### Fixed
 
 - Keep store editors state when hidden by store preview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.10.3] - 2019-05-28
 ### Fixed
+
+- Keep store editors state when hidden by store preview.
+
+## [3.10.3] - 2019-05-28
+
+### Fixed
+
 - Add i18n to editor description field
 
 ## [3.10.2] - 2019-05-23

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {
@@ -26,9 +26,7 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish -r vtex --verbose"

--- a/messages/en.json
+++ b/messages/en.json
@@ -145,7 +145,7 @@
   "admin/pages.editor.configuration.tag.sitewide": "Entire site",
   "admin/pages.editor.configuration.tag.subcategory": "Subcategory: {id}",
   "admin/pages.editor.configuration.tag.template": "This template",
-  "admin/pages.editor.container.editpath.label": "Page URL",
+  "admin/pages.editor.container.editpath.label": "Page URL:",
   "admin/pages.editor.store.button.back.title": "Back to editor",
   "admin/pages.editor.store.button.settings.title": "Store",
   "admin/pages.editor.store.button.template.title": "Template",

--- a/messages/es.json
+++ b/messages/es.json
@@ -145,7 +145,7 @@
   "admin/pages.editor.configuration.tag.sitewide": "Todo el sitio",
   "admin/pages.editor.configuration.tag.subcategory": "Subcategoría: {id}",
   "admin/pages.editor.configuration.tag.template": "Este template",
-  "admin/pages.editor.container.editpath.label": "URL de la página",
+  "admin/pages.editor.container.editpath.label": "URL de la página:",
   "admin/pages.editor.store.button.back.title": "Volver al editor",
   "admin/pages.editor.store.button.settings.title": "Tienda",
   "admin/pages.editor.store.button.template.title": "Modelos",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -145,7 +145,7 @@
   "admin/pages.editor.configuration.tag.sitewide": "Todo o site",
   "admin/pages.editor.configuration.tag.subcategory": "Subcategoria: {id}",
   "admin/pages.editor.configuration.tag.template": "Este template",
-  "admin/pages.editor.container.editpath.label": "URL da página",
+  "admin/pages.editor.container.editpath.label": "URL da página:",
   "admin/pages.editor.store.button.back.title": "Voltar para o editor",
   "admin/pages.editor.store.button.settings.title": "Loja",
   "admin/pages.editor.store.button.template.title": "Templates",

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { defineMessages, injectIntl } from 'react-intl'
+import { defineMessages, InjectedIntlProps, injectIntl } from 'react-intl'
 
 import Modal from '../../Modal'
 
@@ -7,12 +7,11 @@ import Content from './Content'
 import { useFormMetaContext } from './FormMetaContext'
 import { useModalContext } from './ModalContext'
 
-interface CustomProps {
+interface Props extends InjectedIntlProps {
   highlightHandler: (treePath: string | null) => void
   runtime: RenderContext
+  visible: boolean
 }
-
-type Props = CustomProps & ReactIntl.InjectedIntlProps
 
 const messages = defineMessages({
   discard: {
@@ -33,6 +32,7 @@ const Sidebar: React.FunctionComponent<Props> = ({
   highlightHandler,
   intl,
   runtime,
+  visible,
 }) => {
   const formMeta = useFormMetaContext()
   const modal = useModalContext()
@@ -40,7 +40,9 @@ const Sidebar: React.FunctionComponent<Props> = ({
   return (
     <div
       id="sidebar-vtex-editor"
-      className="z-1 h-100 top-3em-ns calc--height-ns w-18em-ns w-100 w-auto-ns flex flex-row-reverse overflow-x-auto"
+      className={`z-1 h-100 top-3em-ns calc--height-ns w-18em-ns w-100 w-auto-ns ${
+        visible ? 'flex' : 'dn'
+      } flex-row-reverse overflow-x-auto`}
     >
       <nav
         id="admin-sidebar"

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -40,9 +40,11 @@ const Sidebar: React.FunctionComponent<Props> = ({
   return (
     <div
       id="sidebar-vtex-editor"
-      className={`z-1 h-100 top-3em-ns calc--height-ns w-18em-ns w-100 w-auto-ns ${
-        visible ? 'flex' : 'dn'
-      } flex-row-reverse overflow-x-auto`}
+      className={
+        visible
+          ? 'z-1 h-100 top-3em-ns calc--height-ns w-18em-ns w-100 w-auto-ns flex flex-row-reverse overflow-x-auto'
+          : 'dn'
+      }
     >
       <nav
         id="admin-sidebar"

--- a/react/components/EditorContainer/StoreEditor/Styles/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/index.tsx
@@ -66,15 +66,18 @@ const removeStyleTag = (window: Window, id: string) => {
 const Styles: React.FunctionComponent<Props> = ({ iframeWindow }) => {
   const [editing, setEditing] = useState<EditingState>(undefined)
 
-  useEffect(() => {
-    createStyleTag(iframeWindow, PATH_STYLE_TAG_ID)
-    createStyleTag(iframeWindow, SHEET_STYLE_TAG_ID)
+  useEffect(
+    () => {
+      createStyleTag(iframeWindow, PATH_STYLE_TAG_ID)
+      createStyleTag(iframeWindow, SHEET_STYLE_TAG_ID)
 
-    return () => {
-      removeStyleTag(iframeWindow, PATH_STYLE_TAG_ID)
-      removeStyleTag(iframeWindow, SHEET_STYLE_TAG_ID)
-    }
-  })
+      return () => {
+        removeStyleTag(iframeWindow, PATH_STYLE_TAG_ID)
+        removeStyleTag(iframeWindow, SHEET_STYLE_TAG_ID)
+      }
+    },
+    [editing]
+  )
 
   return editing ? (
     <StyleEditor

--- a/react/components/EditorContainer/StoreEditor/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/index.tsx
@@ -6,6 +6,7 @@ import Styles from './Styles'
 interface Props {
   editor: EditorContext
   mode: StoreEditMode
+  visible?: boolean
 }
 
 const Mode = ({ editor, mode }: Props) => {
@@ -20,7 +21,9 @@ const Mode = ({ editor, mode }: Props) => {
 const StoreEditor: React.FunctionComponent<Props> = (props: Props) => {
   return (
     <div
-      className="h-100 mr5 bg-base ba b--muted-4 br3"
+      className={`h-100 mr5 bg-base ba b--muted-4 br3${
+        props.visible ? '' : ' dn'
+      }`}
       style={{
         minWidth: '31rem',
         width: '31rem',

--- a/react/components/EditorContainer/StoreEditor/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/index.tsx
@@ -21,9 +21,7 @@ const Mode = ({ editor, mode }: Props) => {
 const StoreEditor: React.FunctionComponent<Props> = (props: Props) => {
   return (
     <div
-      className={`h-100 mr5 bg-base ba b--muted-4 br3${
-        props.visible ? '' : ' dn'
-      }`}
+      className={props.visible ? 'h-100 mr5 bg-base ba b--muted-4 br3' : 'dn'}
       style={{
         minWidth: '31rem',
         width: '31rem',

--- a/react/components/EditorContainer/Topbar/index.tsx
+++ b/react/components/EditorContainer/Topbar/index.tsx
@@ -19,9 +19,9 @@ const Topbar: React.FunctionComponent<Props> = ({
   visible,
 }) => (
   <div
-    className={`ph5 f6 h-3em w-100 ${
-      visible ? 'flex' : 'dn'
-    } justify-between items-center`}
+    className={
+      visible ? 'ph5 f6 h-3em w-100 flex justify-between items-center' : 'dn'
+    }
   >
     <div className="flex items-stretch">
       {mode ? (
@@ -40,7 +40,7 @@ const Topbar: React.FunctionComponent<Props> = ({
           ))}
           <div className="flex items-center mv4 pl5 bw1 bl b--muted-5">
             <FormattedMessage id="admin/pages.editor.container.editpath.label" />
-            :<div className="pl3 c-muted-2">{urlPath}</div>
+            <div className="pl3 c-muted-2">{urlPath}</div>
           </div>
         </Fragment>
       )}

--- a/react/components/EditorContainer/Topbar/index.tsx
+++ b/react/components/EditorContainer/Topbar/index.tsx
@@ -9,14 +9,20 @@ interface Props {
   changeMode: (mode?: StoreEditMode) => void
   mode?: StoreEditMode
   urlPath: string
+  visible: boolean
 }
 
 const Topbar: React.FunctionComponent<Props> = ({
   changeMode,
   mode,
   urlPath,
+  visible,
 }) => (
-  <div className="ph5 f6 h-3em w-100 flex justify-between items-center">
+  <div
+    className={`ph5 f6 h-3em w-100 ${
+      visible ? 'flex' : 'dn'
+    } justify-between items-center`}
+  >
     <div className="flex items-stretch">
       {mode ? (
         <Fragment>
@@ -33,8 +39,8 @@ const Topbar: React.FunctionComponent<Props> = ({
             />
           ))}
           <div className="flex items-center mv4 pl5 bw1 bl b--muted-5">
-            <FormattedMessage id="admin/pages.editor.container.editpath.label" />:
-            <div className="pl3 c-muted-2">{urlPath}</div>
+            <FormattedMessage id="admin/pages.editor.container.editpath.label" />
+            :<div className="pl3 c-muted-2">{urlPath}</div>
           </div>
         </Fragment>
       )}

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -99,18 +99,20 @@ const EditorContainer: React.FC<Props> = ({
       <ModalProvider>
         <IframeNavigationController iframeRuntime={runtime} />
         <div className="w-100 h-100 flex flex-column flex-row-reverse-l flex-wrap-l bg-base bb bw1 b--muted-5">
-          {visible && !storeEditMode && runtime && (
+          {!storeEditMode && runtime && (
             <Sidebar
               highlightHandler={highlightExtensionPoint}
               runtime={runtime}
+              visible={visible}
             />
           )}
           <div className="calc--height-ns flex-grow-1 db-ns dn">
-            {visible && runtime && (
+            {runtime && (
               <Topbar
                 changeMode={setStoreEditMode}
                 mode={storeEditMode}
                 urlPath={iframeWindow.location.pathname}
+                visible={visible}
               />
             )}
             <div
@@ -120,8 +122,12 @@ const EditorContainer: React.FC<Props> = ({
                   : 'top-0 w-100 h-100'
               }`}
             >
-              {visible && runtime && storeEditMode && (
-                <StoreEditor editor={editor} mode={storeEditMode} />
+              {runtime && storeEditMode && (
+                <StoreEditor
+                  editor={editor}
+                  mode={storeEditMode}
+                  visible={visible}
+                />
               )}
               <div id={APP_CONTENT_ELEMENT_ID} className="relative w-100 h-100">
                 <Draggable

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -218,7 +218,6 @@ class EditorProvider extends Component<Props, State> {
 
   public handleToggleShowAdminControls = () => {
     const showAdminControls = !this.state.showAdminControls
-    const editMode = false
 
     Array.prototype.forEach.call(
       document.getElementsByClassName('render-container'),
@@ -228,7 +227,7 @@ class EditorProvider extends Component<Props, State> {
           : e.classList.remove('editor-provider')
     )
 
-    this.setState({ showAdminControls, editMode })
+    this.setState({ showAdminControls })
   }
 
   public handleAddCondition = (conditionId: string) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To persist editor state when previewing website.

#### What problem is this solving?
Editor losing state when previewing website.

#### How should this be manually tested?
Change state on any storefront editor (e.g. content or styles).
Click on the little eye on the draggable widget inside the store iframe.
Watch the editor vanish.
Click on the little pencil which replaced the little eye on the draggable widget inside the store iframe.
Watch the editor raise from the ashes with same state.

All this can be done on https://fixhideeditor--storecomponents.myvtexdev.com/admin/cms/storefront

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
