### PR TITLE
Insert style editor tags right after original tachyons tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.12.1] - 2019-05-29
+
 ### Fixed
 
 - Fixed style editor preview where tachyons was overriding components' css override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed style editor preview where tachyons was overriding components' css override.
+
 ## [3.12.0] - 2019-05-28
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/EditorContainer/StoreEditor/Styles/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/index.tsx
@@ -50,8 +50,6 @@ const createStyleTag = (window: Window, id: string) => {
   const tachyonsTag = window.document.getElementById('style_link')
   if (tachyonsTag) {
     tachyonsTag.after(styleTag)
-  } else if (window.document.head) {
-    window.document.head.append(styleTag)
   }
 }
 

--- a/react/components/EditorContainer/StoreEditor/Styles/index.tsx
+++ b/react/components/EditorContainer/StoreEditor/Styles/index.tsx
@@ -47,7 +47,10 @@ const createStyleTag = (window: Window, id: string) => {
   }
   const styleTag = window.document.createElement('style')
   styleTag.setAttribute('id', id)
-  if (window.document.head) {
+  const tachyonsTag = window.document.getElementById('style_link')
+  if (tachyonsTag) {
+    tachyonsTag.after(styleTag)
+  } else if (window.document.head) {
     window.document.head.append(styleTag)
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
To insert style editor tags right after original tachyons tag.

#### What problem is this solving?
 Avoid custom styles preview overriding other styles (e.g. component css overrides).

#### How should this be manually tested?
You can test the fix on:
- https://fix--storecomponents.myvtexdev.com/admin/cms/storefront

And reproduce the bug on:
- https://bug--storecomponents.myvtexdev.com/admin/cms/storefront

To do it just open the styles editor and try to edit the first (and selected) style.
On `bug` workspace style of the header will change, on `fix` it will remain the same.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
