### PR TITLE
Fix withPWASettings condition to query the default colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.13.4] - 2019-06-05
+
 ### Fixed
 
 - `withPWASettings` condition to query the default colors from Styles GraphQL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `withPWASettings` condition to query the default colors from Styles GraphQL.
+
 ## [3.13.3] - 2019-06-04
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.13.3",
+  "version": "3.13.4",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
@@ -84,6 +84,7 @@ function withPWASettings<T>(
               {...data}
               {...restPWAQuery}
               manifest={{
+                ...(data.manifest || {}),
                 background_color: color as string,
                 theme_color: color as string,
               }}

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/components/withPWASettings.tsx
@@ -69,7 +69,11 @@ function withPWASettings<T>(
   return (props: T) => (
     <PWAQuery query={PWA}>
       {handleCornerCases<PWAData, {}>(options, ({ data, ...restPWAQuery }) => {
-        if (!data.manifest) {
+        if (
+          !data.manifest ||
+          !data.manifest.background_color ||
+          !data.manifest.theme_color
+        ) {
           const color = path(
             ['selectedStyle', 'config', 'semanticColors', 'background', 'base'],
             data


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

It was missing the fact that when the icons are set before the manifest, the manifest is not empty but the colors are not set.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
