### PR TITLE
Fix Scheduler's 'to' DatePicker's position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Scheduler`'s second `DatePicker`'s (`to`) position.
+
 ## [3.13.1] - 2019-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.13.2] - 2019-06-03
+
 ### Fixed
 
 - `Scheduler`'s second `DatePicker`'s (`to`) position.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/ConditionControls/Scheduler.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/ConditionControls/Scheduler.tsx
@@ -139,6 +139,7 @@ class Scheduler extends Component<Props, State> {
               minDate={this.minDate}
               minTime={this.state.toMinTime}
               onChange={this.handleToChange}
+              positionFixed
               useTime
               value={this.state.to}
             />


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix `Scheduler`'s second `DatePicker`'s (`to`) position.

#### How should this be manually tested?

Workspaces:

- Before: [https://instore.myvtex.com/admin/cms/storefront](https://instore.myvtex.com/admin/cms/storefront);
- After: [https://vtexdaycms--instore.myvtex.com/admin/cms/storefront](https://vtexdaycms--instore.myvtex.com/admin/cms/storefront).

#### Screenshots or example usage

Before:

<img width="504" alt="image" src="https://user-images.githubusercontent.com/8486092/58679420-b84ded00-8339-11e9-824f-e1160b1317ac.png">

<hr>

After:

<img width="540" alt="image" src="https://user-images.githubusercontent.com/8486092/58679367-850b5e00-8339-11e9-87d9-cd6bfe116bf6.png">

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)