### PR TITLE
Fix: deleting content on enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Deleting item when pressing Enter inside a carousel
+
 ## [3.13.2] - 2019-06-03
 
 ### Fixed

--- a/react/components/form/ArrayFieldTemplateItem.tsx
+++ b/react/components/form/ArrayFieldTemplateItem.tsx
@@ -84,6 +84,7 @@ class ArrayFieldTemplateItem extends Component<Props, State> {
           <div className="flex items-center accordion-label-buttons">
             {hasRemove && (
               <button
+                type="button"
                 className="accordion-icon-button accordion-icon-button--remove"
                 onClick={stopPropagation(onDropIndexClick(formIndex))}
               >


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
The trash icon button was being triggered when pressing enter because
any `<button>` inside a `form` is interpreted as `type="submit"` by
default. This sets it to `type="button"`, which is not triggered when
submitting the form.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Pressing enter was deleting the content

#### How should this be manually tested?
https://nardi--storecomponents.myvtex.com/admin/cms/storefront
Edit a carousel item, click inside a field and press enter. It should
not be deleted — only saved.

#### Screenshots or example usage
![pressing enter delete](https://user-images.githubusercontent.com/1354492/58823709-bb362f80-8610-11e9-879f-45add4fca090.gif)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.