### PR TITLE
Fix routeId generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.13.5] - 2019-06-06
+
 ### Fixed
 
 - Use regex to replace all '/' to generate routeId.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use regex to replace all '/' to generate routeId.
+
 ## [3.13.4] - 2019-06-05
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.13.4",
+  "version": "3.13.5",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -12,6 +12,7 @@ import {
 
 import { formatStatements } from '../../../../utils/conditions'
 import { isNewRoute } from '../utils'
+import { generateNewRouteId } from './utils'
 
 import Form from './Form'
 import {
@@ -282,11 +283,7 @@ class FormContainer extends Component<Props, State> {
                   }
                 }),
                 path,
-                routeId:
-                  routeId ||
-                  `${interfaceId}#${path
-                    .replace('/', '')
-                    .replace(/\//gi, '-')}`,
+                routeId: routeId || generateNewRouteId(interfaceId, path),
                 title,
                 uuid,
               },

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -282,7 +282,11 @@ class FormContainer extends Component<Props, State> {
                   }
                 }),
                 path,
-                routeId: routeId || `${interfaceId}#${path.replace('/', '')}`,
+                routeId:
+                  routeId ||
+                  `${interfaceId}#${path
+                    .replace('/', '')
+                    .replace(/\//gi, '-')}`,
                 title,
                 uuid,
               },

--- a/react/components/admin/pages/Form/utils.test.ts
+++ b/react/components/admin/pages/Form/utils.test.ts
@@ -1,0 +1,15 @@
+import { generateNewRouteId } from './utils'
+
+describe('#generateNewRouteId', () => {
+  it('should remove trailing slash from path', () => {
+    expect(
+      generateNewRouteId('vtex.store@2.x:store.custom', '/path1/path2/')
+    ).toBe('vtex.store@2.x:store.custom#path1-path2')
+  })
+
+  it('should generate a routeId without "/"', () => {
+    expect(
+      generateNewRouteId('vtex.store@2.x:store.custom', '/path1/path2')
+    ).toEqual(expect.not.stringContaining('/'))
+  })
+})

--- a/react/components/admin/pages/Form/utils.ts
+++ b/react/components/admin/pages/Form/utils.ts
@@ -150,3 +150,12 @@ export const formatToFormData = (route: Route): RouteFormData => {
     })),
   }
 }
+
+export const generateNewRouteId = (interfaceId: string, path: string) => {
+  return `${interfaceId}#${path.replace(
+    /\//gi,
+    (_, offset: number, fullString: string) => {
+      return offset === 0 || offset === fullString.length - 1 ? '' : '-'
+    }
+  )}`
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix bug when creating route.

#### What problem is this solving?
When having nested paths (e.g., `/about/us`), we were creating a routeId with `/` (`about/us`), and this was causing some issues, because the `/` is a special character.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
