### PR TITLE
Fix: update and clean-up steps after configuration deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- When deleting a content configuration, the configuration list's `activeExtension` wasn't being updated and `updateRuntime` wasn't being run synchronously.
+
 ## [3.14.0] - 2019-06-06
 
 ### Added
@@ -19,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Prevent invalid values at `TextArea``.
+- Prevent invalid values at `TextArea`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.14.1] - 2019-06-10
+
 ### Fixed
 
 - When deleting a content configuration, the configuration list's `activeExtension` wasn't being updated and `updateRuntime` wasn't being run synchronously.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "devDependencies": {
     "@vtex/intl-equalizer": "^2.2.1",
     "husky": "^1.1.4",


### PR DESCRIPTION
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
When deleting a content configuration, the configuration list's `activeExtension` wasn't being updated and `updateRuntime` wasn't being run synchronously.

#### How should this be manually tested?
1. Choose any block from the sidebar and click it;
2. Create a new configuration and save it;
3. Delete the configuration you've just created;
4. Open another configuration and close it **without making changes**;
5. Notice that the iframe's Runtime is restored to its current default state (the one that was active before step 4).

#### Screenshots or example usage
Workspace: https://fixconfigdeletionactiveextension--storecomponents.myvtex.com/admin/cms/storefront.

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)