### PR TITLE
Warn user when editing in development workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add warning to top of storefront when user is in development mode telling
+  changes to content can't be promoted
 
 ## [4.0.0] - 2019-06-18
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,7 @@
   "admin/pages.editor.components.modal.button.discard": "Discard",
   "admin/pages.editor.components.modal.text": "You have unsaved modifications.",
   "admin/pages.editor.components.title": "Blocks",
+  "admin/pages.editor.container.dev-mode-warning.text": "You are in develompent mode. Changes to the content will not go to production.",
   "admin/pages.editor.configuration.button.create": "New content",
   "admin/pages.editor.configuration.condition.date.from": "Start:",
   "admin/pages.editor.configuration.condition.date.to": "End:",

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,7 +141,7 @@
   "admin/pages.editor.components.modal.button.discard": "Discard",
   "admin/pages.editor.components.modal.text": "You have unsaved modifications.",
   "admin/pages.editor.components.title": "Blocks",
-  "admin/pages.editor.container.dev-mode-warning.text": "You are in develompent mode. Changes to the content will not go to production.",
+  "admin/pages.editor.container.dev-mode-warning.text": "You are in development mode. Changes to the content will not go to production.",
   "admin/pages.editor.configuration.button.create": "New content",
   "admin/pages.editor.configuration.condition.date.from": "Start:",
   "admin/pages.editor.configuration.condition.date.to": "End:",

--- a/messages/es.json
+++ b/messages/es.json
@@ -141,6 +141,7 @@
   "admin/pages.editor.components.modal.button.discard": "Descartar",
   "admin/pages.editor.components.modal.text": "Tiene modificaciones no guardadas.",
   "admin/pages.editor.components.title": "Bloques",
+  "admin/pages.editor.container.dev-mode-warning.text": "Usted está en el modo de desarrollo. Los cambios en el contenido no podrán ir a la tienda en producción.",
   "admin/pages.editor.configuration.button.create": "Nuevo contenido",
   "admin/pages.editor.configuration.condition.date.from": "Inicio:",
   "admin/pages.editor.configuration.condition.date.to": "Fin:",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -141,6 +141,7 @@
   "admin/pages.editor.components.modal.button.discard": "Descartar",
   "admin/pages.editor.components.modal.text": "Você tem modificações não salvas.",
   "admin/pages.editor.components.title": "Blocos",
+  "admin/pages.editor.container.dev-mode-warning.text": "Você está em modo de desenvolvimento. Mudanças no conteúdo não poderão ir pra loja em produção.",
   "admin/pages.editor.configuration.button.create": "Novo conteúdo",
   "admin/pages.editor.configuration.condition.date.from": "Início:",
   "admin/pages.editor.configuration.condition.date.to": "Fim:",

--- a/react/components/EditorContainer/Topbar/index.tsx
+++ b/react/components/EditorContainer/Topbar/index.tsx
@@ -46,7 +46,9 @@ const Topbar: React.FunctionComponent<Props> = ({
     onChangeUrlPath(url)
   }
 
-  const handleUrlKeyPress = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+  const handleUrlKeyPress = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ): void => {
     onEnter(e, handleNavigateToUrl)
   }
 

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -130,7 +130,7 @@ const EditorContainer: React.FC<Props> = ({
                 <Alert type="warning">
                   <FormattedMessage
                     id="admin/pages.editor.container.dev-mode-warning.text"
-                    defaultMessage="You are in develompent mode. Changes to the content will not go to production."
+                    defaultMessage="You are in development mode. Changes to the content will not go to production."
                   />
                 </Alert>
               </div>

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -2,6 +2,7 @@ import debounce from 'lodash.debounce'
 import { path } from 'ramda'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import Draggable from 'react-draggable'
+import { FormattedMessage } from 'react-intl'
 import { Alert } from 'vtex.styleguide'
 
 import { State as HighlightOverlayState } from '../../HighlightOverlay'
@@ -127,8 +128,10 @@ const EditorContainer: React.FC<Props> = ({
             {isDevelopment && (
               <div className="pa5 bg-muted-5">
                 <Alert type="warning">
-                  Você está em modo de desenvolvimento. Mudanças no conteúdo não
-                  poderão ir pra loja em produção.
+                  <FormattedMessage
+                    id="admin/pages.editor.container.dev-mode-warning.text"
+                    defaultMessage="You are in develompent mode. Changes to the content will not go to production."
+                  />
                 </Alert>
               </div>
             )}

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -2,6 +2,7 @@ import debounce from 'lodash.debounce'
 import { path } from 'ramda'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import Draggable from 'react-draggable'
+import { Alert } from 'vtex.styleguide'
 
 import { State as HighlightOverlayState } from '../../HighlightOverlay'
 
@@ -63,7 +64,13 @@ const EditorContainer: React.FC<Props> = ({
   viewports,
   visible,
 }) => {
-  const { editMode, editExtensionPoint, viewport, iframeWindow, onChangeIframeUrl } = editor
+  const {
+    editMode,
+    editExtensionPoint,
+    viewport,
+    iframeWindow,
+    onChangeIframeUrl,
+  } = editor
   const [storeEditMode, setStoreEditMode] = useState<StoreEditMode>()
 
   const highlightExtensionPoint = useCallback(
@@ -93,6 +100,7 @@ const EditorContainer: React.FC<Props> = ({
   )
 
   const containerProps = useMemo(() => getContainerProps(viewport), [viewport])
+  const isDevelopment = runtime && runtime.production === false
 
   return (
     <FormMetaProvider>
@@ -106,7 +114,7 @@ const EditorContainer: React.FC<Props> = ({
               visible={visible}
             />
           )}
-          <div className="min-vh-100 flex-grow-1 db-ns dn">
+          <div className="flex-grow-1 db-ns dn">
             {runtime && (
               <Topbar
                 changeMode={setStoreEditMode}
@@ -116,10 +124,18 @@ const EditorContainer: React.FC<Props> = ({
                 visible={visible}
               />
             )}
+            {isDevelopment && (
+              <div className="pa5 bg-muted-5">
+                <Alert type="warning">
+                  Você está em modo de desenvolvimento. Mudanças no conteúdo não
+                  poderão ir pra loja em produção.
+                </Alert>
+              </div>
+            )}
             <div
               className={`pa5 bg-muted-5 flex items-start z-0 center-m left-0-m overflow-x-auto-m ${
                 visible && runtime
-                  ? 'calc--height-relative'
+                  ? `calc--height-relative${isDevelopment ? '--dev' : ''}`
                   : 'top-0 w-100 h-100'
               }`}
             >

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -152,6 +152,10 @@
   height: calc(100% - 3em);
 }
 
+.calc--height-relative--dev {
+  height: calc(100% - 8.5em);
+}
+
 /* Non small */
 @media screen and (min-width: 30em) {
   .h-3em-ns {


### PR DESCRIPTION
#### What problem is this solving?
Several users are editing content in development workspace and are ending up
loosing that work because development workspace cannot be promoted to
production.

This PR adds a warning when in development mode so users will be able to
differentiate both environments.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://nardi--storecomponents.myvtex.com/admin/cms/storefront/)

When entering in the storefront in development mode (link above) you
will see a yellow warning telling you not add real changes.

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![Screen Shot 2019-06-21 at 17 04 35](https://user-images.githubusercontent.com/1354492/59949778-8c122180-944a-11e9-8487-ff6c6f7aa6ab.png)


#### Types of changes

<!--- Choose the types related to the PR and delete the non-related ones. -->

- Bug fix (a non-breaking change which fixes an issue)
- New feature (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Technical improvements (chores, refactors and overall reduction of technical debt)

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->