### PR TITLE
Fix/schemaless editable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Prevent click on extensions that have `composition === 'children'`.
+- Change style of items: `ExpandArrow` and `Item` hovers have been separated and no cursor and no hover on uneditable items.
+
 ## [3.15.0] - 2019-06-18
 
 ## [3.14.4] - 2019-06-12

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/ExpandArrow.tsx
@@ -17,15 +17,15 @@ const ExpandArrow: React.FunctionComponent<Props> = ({
   isExpanded,
   onClick,
 }) => (
-  <SideItem horizontalPaddingClassName="ph2" isPointer onClick={onClick}>
+  <SideItem horizontalPaddingClassName="ph3" isPointer onClick={onClick}>
     <div
       className={classnames(`flex items-center color-inherit`, {
-        'pl6 ml2': hasLeftMargin,
+        ph4: hasLeftMargin,
       })}
       style={hasLeftMargin ? {} : { marginRight: 3 }}
     >
       <div
-        className={classnames('color-inherit', styles['transition'], {
+        className={classnames('color-inherit', styles.transition, {
           'rotate-90': isExpanded,
         })}
       >

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
@@ -37,10 +37,8 @@ const Item: React.FunctionComponent<Props> = ({
   let leftPaddingClassName = 'pl8'
   if ((isSortable && !hasSubItems) || isChild) {
     leftPaddingClassName = 'pl5'
-  } else if (isSortable) {
+  } else if (isSortable || hasSubItems) {
     leftPaddingClassName = 'pl2'
-  } else if (hasSubItems) {
-    leftPaddingClassName = 'pl3'
   }
 
   return (

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/Item.tsx
@@ -5,6 +5,7 @@ import { formatIOMessage } from 'vtex.native-types'
 
 interface Props extends InjectedIntlProps {
   hasSubItems?: boolean
+  isEditable: boolean
   isSortable?: boolean
   isChild?: boolean
   onEdit: (event: React.MouseEvent<HTMLDivElement>) => void
@@ -24,6 +25,7 @@ const messages = defineMessages({
 const Item: React.FunctionComponent<Props> = ({
   hasSubItems,
   intl,
+  isEditable,
   isSortable,
   isChild,
   onEdit,
@@ -45,7 +47,10 @@ const Item: React.FunctionComponent<Props> = ({
     <div
       className={classnames(
         'w-100 pv5 pr0 dark-gray bg-inherit tl',
-        leftPaddingClassName
+        leftPaddingClassName,
+        {
+          'hover-bg-light-silver': isEditable,
+        }
       )}
       data-tree-path={treePath}
       key={treePath}
@@ -55,6 +60,7 @@ const Item: React.FunctionComponent<Props> = ({
       style={{
         ...{ animationDuration: '0.2s' },
         ...(!hasSubItems || isSortable ? { marginLeft: 1 } : null),
+        ...{ cursor: isEditable ? 'pointer' : 'default' },
       }}
     >
       <span className={`f6 fw4 track-1 ${isChild ? 'pl7' : 'pl2'}`}>

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/SideItem.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/SideItem.tsx
@@ -17,7 +17,7 @@ const SideItem: React.FunctionComponent<Props> = ({
 }) => (
   <div
     className={classnames(
-      `flex items-center pv5 bg-inherit c-muted-3 hover-black-90`,
+      `flex items-center pv5 bg-inherit c-muted-3 hover-bg-light-silver hover-black-90`,
       { pointer: isPointer },
       horizontalPaddingClassName
     )}

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
@@ -13,7 +13,7 @@ import { ActionMenuOption } from './typings'
 interface CustomProps extends SortableElementProps {
   component: NormalizedComponent
   onDelete: (treePath: string) => void
-  onEdit: (event: React.MouseEvent<HTMLDivElement>) => void
+  onEdit: (event: NormalizedComponent) => void
   onMouseEnter: (
     event: React.MouseEvent<HTMLDivElement | HTMLLIElement>
   ) => void
@@ -81,7 +81,7 @@ class SortableListItem extends Component<Props, State> {
           <Item
             hasSubItems={hasSubItems}
             isSortable={component.isSortable}
-            onEdit={onEdit}
+            onEdit={this.handleClick}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             title={component.name}
@@ -126,6 +126,10 @@ class SortableListItem extends Component<Props, State> {
         )}
       </>
     )
+  }
+
+  private handleClick = () => {
+    this.props.onEdit(this.props.component)
   }
 
   private handleDelete = () => {

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/SortableListItem/index.tsx
@@ -60,7 +60,7 @@ class SortableListItem extends Component<Props, State> {
     return (
       <>
         <div
-          className="flex items-center bb bg-white hover-bg-light-silver b--light-silver"
+          className="flex items-center bb bg-white b--light-silver"
           data-tree-path={component.treePath}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
@@ -80,6 +80,7 @@ class SortableListItem extends Component<Props, State> {
           )}
           <Item
             hasSubItems={hasSubItems}
+            isEditable={component.isEditable}
             isSortable={component.isSortable}
             onEdit={this.handleClick}
             onMouseEnter={onMouseEnter}

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
@@ -19,7 +19,7 @@ type Props = CustomProps
 
 const SortableList = SortableContainer<Props>(
   ({ components, onDelete, onEdit, onMouseEnter, onMouseLeave }) => (
-    <ul className="mv0 pl0 overflow-y-auto pointer">
+    <ul className="mv0 pl0 overflow-y-auto">
       {components.map((component, index) => (
         <SortableListItem
           component={component}

--- a/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/SortableList/index.tsx
@@ -8,7 +8,7 @@ import SortableListItem from './SortableListItem'
 interface CustomProps {
   components: NormalizedComponent[]
   onDelete: (treePath: string) => void
-  onEdit: (event: React.MouseEvent<HTMLDivElement>) => void
+  onEdit: (component: NormalizedComponent) => void
   onMouseEnter: (
     event: React.MouseEvent<HTMLDivElement | HTMLLIElement>
   ) => void

--- a/react/components/EditorContainer/Sidebar/ComponentList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentList/index.tsx
@@ -250,19 +250,19 @@ class ComponentList extends Component<Props, State> {
     )
   }
 
-  private handleEdit = (event: React.MouseEvent<HTMLDivElement>) => {
+  private handleEdit = (component: NormalizedComponent) => {
     if (this.state.changes.length > 0) {
       this.setState({
         isModalOpen: true,
       })
     } else {
       const { editor, highlightHandler } = this.props
+      const { treePath, isEditable } = component
 
-      const treePath = event.currentTarget.getAttribute('data-tree-path')
-
-      editor.editExtensionPoint(treePath)
-
-      highlightHandler(null)
+      if (isEditable) {
+        editor.editExtensionPoint(treePath)
+        highlightHandler(null)
+      }
     }
   }
 

--- a/react/components/EditorContainer/Sidebar/ComponentList/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/typings.d.ts
@@ -2,6 +2,7 @@ import { SidebarComponent } from '../typings'
 
 export interface NormalizedComponent extends SidebarComponent {
   components: NormalizedComponent[]
+  isEditable: boolean
   isSortable: boolean
 }
 

--- a/react/components/EditorContainer/Sidebar/ComponentList/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/utils.test.ts
@@ -24,20 +24,46 @@ describe('normalize', () => {
 
   it('nests store.home/ level components', () => {
     const input: SidebarComponent[] = [
-      { name: 'editor.footer.title', treePath: 'store.home/$after_0' },
-      { name: 'editor.header.title', treePath: 'store.home/$before_0' },
       {
+        isEditable: true,
+        name: 'editor.footer.title',
+        treePath: 'store.home/$after_0',
+      },
+      {
+        isEditable: true,
+        name: 'editor.header.title',
+        treePath: 'store.home/$before_0',
+      },
+      {
+        isEditable: true,
         name: 'editor.category-menu.title',
         treePath: 'store.home/$before_0/category-menu',
       },
-      { name: 'editor.login.title', treePath: 'store.home/$before_0/login' },
-      { name: 'editor.menu', treePath: 'store.home/$before_0/menu-link' },
       {
+        isEditable: true,
+        name: 'editor.login.title',
+        treePath: 'store.home/$before_0/login',
+      },
+      {
+        isEditable: true,
+        name: 'editor.menu',
+        treePath: 'store.home/$before_0/menu-link',
+      },
+      {
+        isEditable: true,
         name: 'editor.minicart.title',
         treePath: 'store.home/$before_0/minicart',
       },
-      { name: 'editor.carousel.title', treePath: 'store.home/carousel#home' },
-      { name: 'editor.shelf.title', treePath: 'store.home/shelf#home' },
+      {
+        isEditable: true,
+        name: 'editor.carousel.title',
+        treePath: 'store.home/carousel#home',
+      },
+      {
+        isEditable: true,
+        name: 'editor.shelf.title',
+        treePath: 'store.home/shelf#home',
+      },
     ]
 
     const expectedOutput: NormalizedComponent[] = [
@@ -45,55 +71,55 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.category-menu.title',
             treePath: 'store.home/$before_0/category-menu',
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.login.title',
             treePath: 'store.home/$before_0/login',
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.menu',
             treePath: 'store.home/$before_0/menu-link',
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.minicart.title',
             treePath: 'store.home/$before_0/minicart',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -107,34 +133,42 @@ describe('normalize', () => {
   it('preserves multilevel structures', () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
+        isEditable: true,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0/menu',
       },
       {
+        isEditable: true,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
+        isEditable: true,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath: 'store.home/shelf#home/product-summary',
       },
       {
+        isEditable: true,
         name: 'editor.product-rating.title',
         treePath: 'store.home/shelf#home/product-summary/product-rating',
       },
       {
+        isEditable: true,
         name: 'editor.product-rating.start.title',
         treePath: 'store.home/shelf#home/product-summary/product-rating/start',
       },
       {
+        isEditable: true,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
       },
@@ -145,20 +179,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.header.title',
             treePath: 'store.home/$before_0/menu',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
@@ -171,34 +205,34 @@ describe('normalize', () => {
                 components: [
                   {
                     components: [],
-                    isEditable: false,
+                    isEditable: true,
                     isSortable: false,
                     name: 'editor.product-rating.start.title',
                     treePath:
                       'store.home/shelf#home/product-summary/product-rating/start',
                   },
                 ],
-                isEditable: false,
+                isEditable: true,
                 isSortable: false,
                 name: 'editor.product-rating.title',
                 treePath:
                   'store.home/shelf#home/product-summary/product-rating',
               },
             ],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -211,16 +245,19 @@ describe('normalize', () => {
   it('should treat "closest" node as next root', () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath:
           'store.home/shelf#home/spacer/placeholder/flex/product-summary',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.star.title',
         treePath:
           'store.home/shelf#home/spacer/placeholder/flex/product-summary/star',
       },
       {
+        isEditable: true,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
@@ -233,21 +270,21 @@ describe('normalize', () => {
             components: [
               {
                 components: [],
-                isEditable: false,
+                isEditable: true,
                 isSortable: false,
                 name: 'editor.product-summary.star.title',
                 treePath:
                   'store.home/shelf#home/spacer/placeholder/flex/product-summary/star',
               },
             ],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath:
               'store.home/shelf#home/spacer/placeholder/flex/product-summary',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
@@ -260,22 +297,27 @@ describe('normalize', () => {
   it('handles unordered components', () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath: 'store.home/shelf#home/product-summary',
       },
       {
+        isEditable: true,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
+        isEditable: true,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
+        isEditable: true,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
@@ -284,14 +326,14 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
@@ -300,20 +342,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -326,30 +368,37 @@ describe('normalize', () => {
   it(`handles components with 'around' blocks`, () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
+        isEditable: true,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath: 'store.home/shelf#home/product-summary',
       },
       {
+        isEditable: true,
         name: 'editor.around-shelf.title',
         treePath: 'store.home/shelf#home/$around_0',
       },
       {
+        isEditable: true,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
+        isEditable: true,
         name: 'editor.around-carousel.title',
         treePath: 'store.home/carousel#home/$around_0',
       },
       {
+        isEditable: true,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
       },
@@ -358,28 +407,28 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.around-carousel.title',
         treePath: 'store.home/carousel#home/$around_0',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.around-shelf.title',
         treePath: 'store.home/shelf#home/$around_0',
@@ -388,20 +437,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -414,14 +463,17 @@ describe('normalize', () => {
   it('should handle treePaths with same beginning but that are different blocks', () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.carousel.title',
         treePath: 'store.home/layout#home',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath: 'store.home/layout#homeCollection',
       },
       {
+        isEditable: true,
         name: 'editor.product-summary.title',
         treePath: 'store.home/layout#homeCollection/button',
       },
@@ -430,7 +482,7 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/layout#home',
@@ -439,13 +491,13 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/layout#homeCollection/button',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.product-summary.title',
         treePath: 'store.home/layout#homeCollection',
@@ -459,35 +511,42 @@ describe('normalize', () => {
   it('should put components in closest ancestor', () => {
     const input: SidebarComponent[] = [
       {
+        isEditable: true,
         name: 'editor.row.title',
         treePath: 'store.home/flex-layout.row#homeCollections',
       },
       {
+        isEditable: true,
         name: 'admin/editor.rich-text.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#leftCollection/rich-text#homeCollectionsTitle',
       },
       {
+        isEditable: true,
         name: 'admin/editor.info-card.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#middleCollection/flex-layout.row#homeCollectionsBottom/info-card#homeBannerDCComics',
       },
       {
+        isEditable: true,
         name: 'admin/editor.info-card.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#middleCollection/flex-layout.row#homeCollectionsBottom/info-card#homeBannerMarvel',
       },
       {
+        isEditable: true,
         name: 'admin/editor.info-card.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#middleCollection/flex-layout.row#homeCollectionsTop/info-card#homeBannerAngel',
       },
       {
+        isEditable: true,
         name: 'admin/editor.info-card.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#middleCollection/flex-layout.row#homeCollectionsTop/info-card#homeBannerSeaHunter',
       },
       {
+        isEditable: true,
         name: 'admin/editor.info-card.title',
         treePath:
           'store.home/flex-layout.row#homeCollections/flex-layout.col#rightCollection/info-card#homeCollectionsDisney',
@@ -499,7 +558,7 @@ describe('normalize', () => {
         components: [
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.rich-text.title',
             treePath:
@@ -507,7 +566,7 @@ describe('normalize', () => {
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -515,7 +574,7 @@ describe('normalize', () => {
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -523,7 +582,7 @@ describe('normalize', () => {
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -531,7 +590,7 @@ describe('normalize', () => {
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -539,14 +598,14 @@ describe('normalize', () => {
           },
           {
             components: [],
-            isEditable: false,
+            isEditable: true,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
               'store.home/flex-layout.row#homeCollections/flex-layout.col#rightCollection/info-card#homeCollectionsDisney',
           },
         ],
-        isEditable: false,
+        isEditable: true,
         isSortable: false,
         name: 'editor.row.title',
         treePath: 'store.home/flex-layout.row#homeCollections',
@@ -560,6 +619,7 @@ describe('normalize', () => {
 describe('isRootComponent', () => {
   it(`returns true when called with 'store.home/header.full'`, () => {
     const input: SidebarComponent = {
+      isEditable: true,
       name: 'header',
       treePath: 'store.home/header.full',
     }
@@ -571,6 +631,7 @@ describe('isRootComponent', () => {
 
   it(`returns true when called with 'store.home/footer'`, () => {
     const input: SidebarComponent = {
+      isEditable: true,
       name: 'footer',
       treePath: 'store.home/footer',
     }
@@ -582,6 +643,7 @@ describe('isRootComponent', () => {
 
   it(`returns true when called with 'store.home/test'`, () => {
     const input: SidebarComponent = {
+      isEditable: true,
       name: 'test',
       treePath: 'store.home/test',
     }
@@ -593,6 +655,7 @@ describe('isRootComponent', () => {
 
   it(`returns false when called with 'store.home/header/login'`, () => {
     const input: SidebarComponent = {
+      isEditable: true,
       name: 'login',
       treePath: 'store.home/header.full/login',
     }
@@ -604,6 +667,7 @@ describe('isRootComponent', () => {
 
   it(`returns false when called with 'store.home/shelf/product-summary'`, () => {
     const input: SidebarComponent = {
+      isEditable: true,
       name: 'product-summary',
       treePath: 'store.home/shelf/product-summary',
     }

--- a/react/components/EditorContainer/Sidebar/ComponentList/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/utils.test.ts
@@ -45,47 +45,55 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.category-menu.title',
             treePath: 'store.home/$before_0/category-menu',
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.login.title',
             treePath: 'store.home/$before_0/login',
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.menu',
             treePath: 'store.home/$before_0/menu-link',
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.minicart.title',
             treePath: 'store.home/$before_0/minicart',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -137,17 +145,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.header.title',
             treePath: 'store.home/$before_0/menu',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
@@ -160,29 +171,34 @@ describe('normalize', () => {
                 components: [
                   {
                     components: [],
+                    isEditable: false,
                     isSortable: false,
                     name: 'editor.product-rating.start.title',
                     treePath:
                       'store.home/shelf#home/product-summary/product-rating/start',
                   },
                 ],
+                isEditable: false,
                 isSortable: false,
                 name: 'editor.product-rating.title',
                 treePath:
                   'store.home/shelf#home/product-summary/product-rating',
               },
             ],
+            isEditable: false,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -217,18 +233,21 @@ describe('normalize', () => {
             components: [
               {
                 components: [],
+                isEditable: false,
                 isSortable: false,
                 name: 'editor.product-summary.star.title',
                 treePath:
                   'store.home/shelf#home/spacer/placeholder/flex/product-summary/star',
               },
             ],
+            isEditable: false,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath:
               'store.home/shelf#home/spacer/placeholder/flex/product-summary',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
@@ -265,12 +284,14 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
@@ -279,17 +300,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -334,24 +358,28 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.header.title',
         treePath: 'store.home/$before_0',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.around-carousel.title',
         treePath: 'store.home/carousel#home/$around_0',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/carousel#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.around-shelf.title',
         treePath: 'store.home/shelf#home/$around_0',
@@ -360,17 +388,20 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/shelf#home/product-summary',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.shelf.title',
         treePath: 'store.home/shelf#home',
       },
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.footer.title',
         treePath: 'store.home/$after_0',
@@ -399,6 +430,7 @@ describe('normalize', () => {
     const expectedOutput: NormalizedComponent[] = [
       {
         components: [],
+        isEditable: false,
         isSortable: false,
         name: 'editor.carousel.title',
         treePath: 'store.home/layout#home',
@@ -407,11 +439,13 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'editor.product-summary.title',
             treePath: 'store.home/layout#homeCollection/button',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.product-summary.title',
         treePath: 'store.home/layout#homeCollection',
@@ -465,6 +499,7 @@ describe('normalize', () => {
         components: [
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.rich-text.title',
             treePath:
@@ -472,6 +507,7 @@ describe('normalize', () => {
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -479,6 +515,7 @@ describe('normalize', () => {
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -486,6 +523,7 @@ describe('normalize', () => {
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -493,6 +531,7 @@ describe('normalize', () => {
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
@@ -500,12 +539,14 @@ describe('normalize', () => {
           },
           {
             components: [],
+            isEditable: false,
             isSortable: false,
             name: 'admin/editor.info-card.title',
             treePath:
               'store.home/flex-layout.row#homeCollections/flex-layout.col#rightCollection/info-card#homeCollectionsDisney',
           },
         ],
+        isEditable: false,
         isSortable: false,
         name: 'editor.row.title',
         treePath: 'store.home/flex-layout.row#homeCollections',

--- a/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
@@ -104,7 +104,7 @@ const buildTree = (orderedNodes: ModifiedSidebarComponent[]) => {
     const normalized = {
       ...component,
       components: [],
-      isEditable: component.schema && 'properties' in component.schema,
+      isEditable: !!component.schema && 'properties' in component.schema,
       isSortable: false,
     }
     const parentId = parentTreePath(modifiedTreePath)

--- a/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
@@ -87,11 +87,12 @@ export const normalize = (components: SidebarComponent[]) => {
     return []
   }
   const rootId = components[0].treePath.split('/')[0]
-  const root = { treePath: rootId, name: 'root' }
+  const root = { treePath: rootId, name: 'root', isEditable: false }
   const allComponents = [root, ...components]
 
   const modifiedComponents = hideNonExistentNodesInTreePath(allComponents).sort(
-    (cmp1, cmp2) => modifiedPathLength(cmp1) - modifiedPathLength(cmp2)
+    (cmp1: ModifiedSidebarComponent, cmp2: ModifiedSidebarComponent) =>
+      modifiedPathLength(cmp1) - modifiedPathLength(cmp2)
   )
 
   const nodes = buildTree(modifiedComponents)
@@ -104,7 +105,6 @@ const buildTree = (orderedNodes: ModifiedSidebarComponent[]) => {
     const normalized = {
       ...component,
       components: [],
-      isEditable: !!component.schema && 'properties' in component.schema,
       isSortable: false,
     }
     const parentId = parentTreePath(modifiedTreePath)

--- a/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentList/utils.ts
@@ -101,7 +101,12 @@ export const normalize = (components: SidebarComponent[]) => {
 const buildTree = (orderedNodes: ModifiedSidebarComponent[]) => {
   const nodes: Record<string, NormalizedComponent> = {}
   orderedNodes.forEach(({ modifiedTreePath, ...component }) => {
-    const normalized = { ...component, isSortable: false, components: [] }
+    const normalized = {
+      ...component,
+      components: [],
+      isEditable: component.schema && 'properties' in component.schema,
+      isSortable: false,
+    }
     const parentId = parentTreePath(modifiedTreePath)
     nodes[modifiedTreePath] = normalized
 

--- a/react/components/EditorContainer/Sidebar/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/typings.d.ts
@@ -1,3 +1,5 @@
+import { JSONSchema6 } from 'json-schema'
+
 export interface FormMetaContext {
   addToI18nMapping: (newEntry: Record<string, string>) => void
   clearI18nMapping: () => void
@@ -24,6 +26,7 @@ export interface ModalContext {
 
 export interface SidebarComponent {
   name: string
+  schema?: JSONSchema6
   treePath: string
 }
 

--- a/react/components/EditorContainer/Sidebar/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/typings.d.ts
@@ -26,7 +26,7 @@ export interface ModalContext {
 
 export interface SidebarComponent {
   name: string
-  schema?: JSONSchema6
+  isEditable: boolean
   treePath: string
 }
 

--- a/react/components/EditorContainer/Sidebar/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/utils.test.ts
@@ -63,18 +63,30 @@ describe('getComponents', () => {
     ).toEqual([
       {
         name: 'Carousel',
+        schema: {
+          title: 'Carousel',
+        },
         treePath: 'store/home/carousel',
       },
       {
         name: 'Shelf',
+        schema: {
+          title: 'Shelf',
+        },
         treePath: 'store/home/shelf',
       },
       {
         name: 'Arrow',
+        schema: {
+          title: 'Arrow',
+        },
         treePath: 'store/home/shelf/arrow',
       },
       {
         name: 'Shelf Title',
+        schema: {
+          title: 'Shelf Title',
+        },
         treePath: 'store/home/shelf/title',
       },
     ])
@@ -106,18 +118,30 @@ describe('getComponents', () => {
     ).toEqual([
       {
         name: 'Shelf',
+        schema: {
+          title: 'Shelf',
+        },
         treePath: 'store/home/shelf',
       },
       {
         name: 'Carousel',
+        schema: {
+          title: 'Carousel',
+        },
         treePath: 'store/home/carousel',
       },
       {
         name: 'Arrow',
+        schema: {
+          title: 'Arrow',
+        },
         treePath: 'store/home/shelf/arrow',
       },
       {
         name: 'Shelf Title',
+        schema: {
+          title: 'Shelf Title',
+        },
         treePath: 'store/home/shelf/title',
       },
     ])
@@ -141,6 +165,9 @@ describe('getComponents', () => {
     ).toEqual([
       {
         name: 'Shelf',
+        schema: {
+          title: 'Shelf',
+        },
         treePath: 'store/home/shelf',
       },
     ])

--- a/react/components/EditorContainer/Sidebar/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/utils.test.ts
@@ -62,31 +62,23 @@ describe('getComponents', () => {
       getComponents(mockExtensions as any, mockComponents as any, 'store/home')
     ).toEqual([
       {
+        isEditable: true,
         name: 'Carousel',
-        schema: {
-          title: 'Carousel',
-        },
         treePath: 'store/home/carousel',
       },
       {
+        isEditable: true,
         name: 'Shelf',
-        schema: {
-          title: 'Shelf',
-        },
         treePath: 'store/home/shelf',
       },
       {
+        isEditable: true,
         name: 'Arrow',
-        schema: {
-          title: 'Arrow',
-        },
         treePath: 'store/home/shelf/arrow',
       },
       {
+        isEditable: true,
         name: 'Shelf Title',
-        schema: {
-          title: 'Shelf Title',
-        },
         treePath: 'store/home/shelf/title',
       },
     ])
@@ -117,31 +109,23 @@ describe('getComponents', () => {
       )
     ).toEqual([
       {
+        isEditable: true,
         name: 'Shelf',
-        schema: {
-          title: 'Shelf',
-        },
         treePath: 'store/home/shelf',
       },
       {
+        isEditable: true,
         name: 'Carousel',
-        schema: {
-          title: 'Carousel',
-        },
         treePath: 'store/home/carousel',
       },
       {
+        isEditable: true,
         name: 'Arrow',
-        schema: {
-          title: 'Arrow',
-        },
         treePath: 'store/home/shelf/arrow',
       },
       {
+        isEditable: true,
         name: 'Shelf Title',
-        schema: {
-          title: 'Shelf Title',
-        },
         treePath: 'store/home/shelf/title',
       },
     ])
@@ -164,10 +148,8 @@ describe('getComponents', () => {
       getComponents(extensions as any, components as any, 'store/home')
     ).toEqual([
       {
+        isEditable: true,
         name: 'Shelf',
-        schema: {
-          title: 'Shelf',
-        },
         treePath: 'store/home/shelf',
       },
     ])

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -121,10 +121,14 @@ export function getComponents(
 
       return treePathA > treePathB ? 1 : -1
     })
-    .map<SidebarComponent>(treePath => ({
-      name: extensions[treePath].title || getComponentSchema(treePath).title!,
-      treePath,
-    }))
+    .map<SidebarComponent>(treePath => {
+      const schema = getComponentSchema(treePath)
+      return {
+        name: extensions[treePath].title || schema.title!,
+        schema,
+        treePath,
+      }
+    })
 }
 
 export const getIsSitewide = (extensions: Extensions, editTreePath: string) => {

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -123,9 +123,15 @@ export function getComponents(
     })
     .map<SidebarComponent>(treePath => {
       const schema = getComponentSchema(treePath)
+      const extension = pathOr<Partial<Extension>, Extension>(
+        {},
+        [treePath],
+        extensions
+      )
+
       return {
+        isEditable: extension.composition !== 'children',
         name: extensions[treePath].title || schema.title!,
-        schema,
         treePath,
       }
     })


### PR DESCRIPTION
#### What problem is this solving?

Users could click on block without schema.

#### How should this be manually tested?

[Workspace](https://preventclick--instore.myvtex.com/admin/cms/storefront)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Types of changes

- Bug fix (a non-breaking change which fixes an issue)

#### Notes

If there are any blocks with composition `children` that should be editable, they won't be editable.

[ch13885]
