### PR TITLE
Alert when in master workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,45 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Alert to inform the user in `master` workspace that his changes go to the production store.
+
 ## [4.1.3] - 2019-07-01
+
+## [4.1.2] - 2019-06-27
+
+### Changed
+
+- Changes from `v3.15.2`.
+
+## [4.1.1] - 2019-06-26
+
+### Changed
+
+- Prevent click on extensions that have `composition === 'children'`.
+- Change style of items: `ExpandArrow` and `Item` hovers have been separated and no cursor and no hover on uneditable items.
+
+## [4.1.0] - 2019-06-21
+
+### Added
+
+- Add warning to top of storefront when user is in development mode telling
+  changes to content can't be promoted
+
+## [4.0.0] - 2019-06-18
+
+### Added
+
+- Adds the ability to navigate to a specific URL by editing the storefront URL in the UI
+
+## [4.0.0-beta] - 2019-06-10
+
+### Changed
+
+- [BREAKING] Change routes to be compliance with new admin 3.x architecture `/admin/app/<route>`.
+- [BREAKING] Injects this admin in admin 3.x navigation (loosing compatibility with admin 2.x).
+- Remove some context function calls that were previously injected by admin 2.x
 
 ## [3.15.2] - 2019-06-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,6 @@
   "description": "The VTEX Pages CMS admin interface",
   "builders": {
     "admin": "0.x",
-    "pages": "1.x",
     "messages": "1.x",
     "react": "3.x"
   },

--- a/messages/context.json
+++ b/messages/context.json
@@ -154,6 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "admin/pages.editor.configuration.scope.template.saved",
   "admin/pages.editor.container.dev-mode-warning.text": "admin/pages.editor.container.dev-mode-warning.text",
   "admin/pages.editor.container.editpath.label": "admin/pages.editor.container.editpath.label",
+  "admin/pages.editor.container.master-workspace-warning.text": "admin/pages.editor.container.master-workspace-warning.text",
   "admin/pages.editor.image-uploader.change": "admin/pages.editor.image-uploader.change",
   "admin/pages.editor.image-uploader.empty.button": "admin/pages.editor.image-uploader.empty.button",
   "admin/pages.editor.image-uploader.empty.text": "admin/pages.editor.image-uploader.empty.text",

--- a/messages/en.json
+++ b/messages/en.json
@@ -154,7 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Saved in",
   "admin/pages.editor.container.dev-mode-warning.text": "You are in development mode. Changes to the content will not go to production.",
   "admin/pages.editor.container.editpath.label": "Page URL:",
-  "admin/pages.editor.container.master-workspace-warning.text": "Changes to the content will have an immediate effect. Prefer using draft mode.",
+  "admin/pages.editor.container.master-workspace-warning.text": "You are editing the live store. Changes will have immediate effect.",
   "admin/pages.editor.image-uploader.change": "Change image",
   "admin/pages.editor.image-uploader.empty.button": "Upload",
   "admin/pages.editor.image-uploader.empty.text": "Drag your image here",

--- a/messages/en.json
+++ b/messages/en.json
@@ -154,6 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Saved in",
   "admin/pages.editor.container.dev-mode-warning.text": "You are in development mode. Changes to the content will not go to production.",
   "admin/pages.editor.container.editpath.label": "Page URL:",
+  "admin/pages.editor.container.master-workspace-warning.text": "Changes to the content will have an immediate effect. Prefer using draft mode.",
   "admin/pages.editor.image-uploader.change": "Change image",
   "admin/pages.editor.image-uploader.empty.button": "Upload",
   "admin/pages.editor.image-uploader.empty.text": "Drag your image here",

--- a/messages/es.json
+++ b/messages/es.json
@@ -154,6 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Guardado en el",
   "admin/pages.editor.container.dev-mode-warning.text": "Usted está en el modo de desarrollo. Los cambios en el contenido no podrán ir a la tienda en producción.",
   "admin/pages.editor.container.editpath.label": "URL de la página:",
+  "admin/pages.editor.container.master-workspace-warning.text": "Los cambios en el contenido tendrán un efecto inmediato. Prefiero usar el modo borrador.",
   "admin/pages.editor.image-uploader.change": "Cambiar imagen",
   "admin/pages.editor.image-uploader.empty.button": "Hacer upload",
   "admin/pages.editor.image-uploader.empty.text": "Arrastra tu imagen aquí",

--- a/messages/es.json
+++ b/messages/es.json
@@ -154,7 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Guardado en el",
   "admin/pages.editor.container.dev-mode-warning.text": "Usted está en el modo de desarrollo. Los cambios en el contenido no podrán ir a la tienda en producción.",
   "admin/pages.editor.container.editpath.label": "URL de la página:",
-  "admin/pages.editor.container.master-workspace-warning.text": "Los cambios en el contenido tendrán un efecto inmediato. Prefiero usar el modo borrador.",
+  "admin/pages.editor.container.master-workspace-warning.text": "Usted está editando la tienda en producción. Los cambios en el contenido tendrán un efecto inmediato.",
   "admin/pages.editor.image-uploader.change": "Cambiar imagen",
   "admin/pages.editor.image-uploader.empty.button": "Hacer upload",
   "admin/pages.editor.image-uploader.empty.text": "Arrastra tu imagen aquí",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -154,6 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Salvo no",
   "admin/pages.editor.container.dev-mode-warning.text": "Você está em modo de desenvolvimento. Mudanças no conteúdo não poderão ir pra loja em produção.",
   "admin/pages.editor.container.editpath.label": "URL da página:",
+  "admin/pages.editor.container.master-workspace-warning.text": "Mudanças no conteúdo terão um efeito mediato. Prefira usar o modo rascunho.",
   "admin/pages.editor.image-uploader.change": "Trocar imagem",
   "admin/pages.editor.image-uploader.empty.button": "Fazer upload",
   "admin/pages.editor.image-uploader.empty.text": "Arraste sua imagem aqui",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -154,7 +154,7 @@
   "admin/pages.editor.configuration.scope.template.saved": "Salvo no",
   "admin/pages.editor.container.dev-mode-warning.text": "Você está em modo de desenvolvimento. Mudanças no conteúdo não poderão ir pra loja em produção.",
   "admin/pages.editor.container.editpath.label": "URL da página:",
-  "admin/pages.editor.container.master-workspace-warning.text": "Mudanças no conteúdo terão um efeito mediato. Prefira usar o modo rascunho.",
+  "admin/pages.editor.container.master-workspace-warning.text": "Você está editando a loja em produção. Mudanças no conteúdo terão um efeito mediato.",
   "admin/pages.editor.image-uploader.change": "Trocar imagem",
   "admin/pages.editor.image-uploader.empty.button": "Fazer upload",
   "admin/pages.editor.image-uploader.empty.text": "Arraste sua imagem aqui",

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -135,6 +135,16 @@ const EditorContainer: React.FC<Props> = ({
                 </Alert>
               </div>
             )}
+            {runtime && runtime.workspace === 'master' && (
+              <div className="pa5 bg-muted-5">
+                <Alert type="warning">
+                  <FormattedMessage
+                    id="admin/pages.editor.container.master-workspace-warning.text"
+                    defaultMessage="Changes to the content will have an immediate effect. Prefer using draft mode."
+                  />
+                </Alert>
+              </div>
+            )}
             <div
               className={`pa5 bg-muted-5 flex items-start z-0 center-m left-0-m overflow-x-auto-m ${
                 visible && runtime

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -140,7 +140,7 @@ const EditorContainer: React.FC<Props> = ({
                 <Alert type="warning">
                   <FormattedMessage
                     id="admin/pages.editor.container.master-workspace-warning.text"
-                    defaultMessage="Changes to the content will have an immediate effect. Prefer using draft mode."
+                    defaultMessage="You are editing the live store. Changes will have immediate effect."
                   />
                 </Alert>
               </div>


### PR DESCRIPTION
#### What problem is this solving?
Alerts user that his changes in master will reflect the live store.

#### How should this be manually tested?
To test this, I'd have to launch a beta version and install it in master. Since it's a simple change, I don't think it's necessary.

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
<img width="1372" alt="Screen Shot 2019-06-26 at 14 51 06" src="https://user-images.githubusercontent.com/10400340/60202850-dcf69100-9821-11e9-93b4-395d0c2ba975.png">

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)

