### PR TITLE
Fix/sidebar visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Conditions to show extension on components list: stop considering block `composition` type, and uses whether they're editable or not.
+
+### Fixed
+
+- Showing nested components that are editable.
+- Components list sort logic.
+
 ## [3.15.3] - 2019-07-02
 
 ### Fixed

--- a/react/components/EditorContainer/Sidebar/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getComponents,
   getIsDefaultContent,
   getIsSitewide,
+  hasContentPropsInSchema,
 } from './utils'
 
 describe('getComponents', () => {
@@ -36,23 +37,31 @@ describe('getComponents', () => {
   const mockComponents = {
     'vtex.carousel': {
       schema: {
+        properties: { mock: {} },
         title: 'Carousel',
+        type: 'object',
       },
     },
     'vtex.no-schema': {},
     'vtex.shelf': {
       schema: {
+        properties: { mock: {} },
         title: 'Shelf',
+        type: 'object',
       },
     },
     'vtex.shelf-arrow': {
       schema: {
+        properties: { mock: {} },
         title: 'Arrow',
+        type: 'object',
       },
     },
     'vtex.shelf-title': {
       schema: {
+        properties: { mock: {} },
         title: 'Shelf Title',
+        type: 'object',
       },
     },
   }
@@ -140,7 +149,9 @@ describe('getComponents', () => {
     const components = {
       'vtex.shelf': {
         getSchema: () => ({
+          properties: { mock: {} },
           title: 'Shelf',
+          type: 'object',
         }),
       },
     }
@@ -229,6 +240,7 @@ describe('getIsSitewide', () => {
       composition: 'children' as Extension['composition'],
       content: {},
       context: {},
+      hasContentSchema: false,
       implementationIndex: 0,
       implements: [''],
       preview: { type: 'block' },
@@ -246,6 +258,7 @@ describe('getIsSitewide', () => {
       content: {},
       contentMapId: 'gZQaBBQyU2DLvGaM9icNdg',
       context: {},
+      hasContentSchema: false,
       implementationIndex: 0,
       implements: [''],
       preview: null,
@@ -266,6 +279,7 @@ describe('getIsSitewide', () => {
       component: 'vtex.store@2.11.0/HomeWrapper',
       content: {},
       context: {},
+      hasContentSchema: false,
       implementationIndex: 0,
       implements: [''],
       preview: null,
@@ -282,6 +296,7 @@ describe('getIsSitewide', () => {
       component: 'vtex.store-header@2.11.0/index',
       content: {},
       context: {},
+      hasContentSchema: false,
       implementationIndex: 0,
       implements: [''],
       preview: null,
@@ -299,6 +314,7 @@ describe('getIsSitewide', () => {
       content: {},
       contentMapId: 'eiYc7wanqAEYiPY5DJdRPT',
       context: {},
+      hasContentSchema: false,
       implementationIndex: 0,
       implements: [''],
       preview: null,
@@ -336,5 +352,39 @@ describe('getIsDefaultContent', () => {
 
   it('should return false when origin is null (declared by user)', () => {
     expect(getIsDefaultContent({ origin: null })).toBe(false)
+  })
+})
+
+describe('#hasContentPropsInSchema', () => {
+  it(`should return false when schema isn't type object`, () => {
+    expect(hasContentPropsInSchema({ title: 'Test' })).toBe(false)
+    expect(hasContentPropsInSchema({ type: 'number' })).toBe(false)
+  })
+
+  it(`should return true if there are properties with isLayout falsy`, () => {
+    expect(
+      hasContentPropsInSchema({
+        type: 'object',
+        properties: { test: { isLayout: false } },
+      })
+    ).toBe(true)
+    expect(
+      hasContentPropsInSchema({ type: 'object', properties: { test: {} } })
+    ).toBe(true)
+  })
+
+  it(`should return true if there are nested properties with isLayout falsy`, () => {
+    expect(
+      hasContentPropsInSchema({
+        type: 'object',
+        properties: { test: { isLayout: false } },
+      })
+    ).toBe(true)
+    expect(
+      hasContentPropsInSchema({
+        type: 'object',
+        properties: { test: { type: 'object', properties: { lala: {} } } },
+      })
+    ).toBe(true)
   })
 })

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -1,3 +1,4 @@
+import { JSONSchema6 } from 'json-schema'
 import { has, path, pathOr } from 'ramda'
 import { ComponentsRegistry } from 'vtex.render-runtime'
 
@@ -17,7 +18,18 @@ const isSamePage = (page: string, treePath: string) => {
 
 const getParentContainerBlocksGetter = (extensions: Extensions) => (
   parentPath: string
-) => pathOr<InnerBlock[], InnerBlock[]>([], [parentPath, 'blocks'], extensions)
+) => {
+  const children = pathOr<InnerBlock[], InnerBlock[]>(
+    [],
+    [parentPath, 'children'],
+    extensions
+  )
+  return pathOr<InnerBlock[], InnerBlock[]>(
+    children,
+    [parentPath, 'blocks'],
+    extensions
+  )
+}
 
 const getComponentNameGetterFromExtensions = (extensions: Extensions) => (
   treePath: string
@@ -51,39 +63,60 @@ export function getComponents(
   const getComponentName = getComponentNameGetterFromExtensions(extensions)
   const getComponentSchema = getComponentSchemaGetter(components, extensions)
 
+  const sidebarComponentMap: Record<string, SidebarComponent> = {}
+  const isComponentEditableMap: Record<string, boolean> = {}
+
   return Object.keys(extensions)
     .filter(treePath => {
       const schema = getComponentSchema(treePath)
-      const component = extensions[treePath]
       const componentName = getComponentName(treePath)
       const hasTitleInSchema = has('title', schema)
-      const hasTitle = hasTitleInSchema || has('title', extensions[treePath])
+      const hasTitleInBlock = has('title', extensions[treePath])
+      const extension = pathOr<Partial<Extension>, Extension>(
+        {},
+        [treePath],
+        extensions
+      )
 
-      const isLayoutComponent = component.composition === 'children'
       const isRoot = isRootComponent(2)({ treePath })
+
+      const isEditable = isComponentEditableMap[componentName]
+        ? isComponentEditableMap[componentName]
+        : (isComponentEditableMap[componentName] =
+            extension.hasContentSchema || hasContentPropsInSchema(schema))
 
       if (schema && !hasTitleInSchema) {
         console.warn(generateWarningMessage(componentName))
       }
 
-      return (
+      const shouldShow =
         isSamePage(page, treePath) &&
         !!schema &&
-        hasTitle &&
-        (isRoot || !isLayoutComponent)
-      )
+        (hasTitleInBlock || (isRoot || (hasTitleInSchema && isEditable)))
+
+      if (shouldShow) {
+        sidebarComponentMap[treePath] = {
+          isEditable,
+          name: extensions[treePath].title || schema.title!,
+          treePath,
+        }
+      }
+
+      return shouldShow
     })
     .sort((treePathA, treePathB) => {
-      const parentPathA = `${treePathA.split('/')[0]}/${
-        treePathA.split('/')[1]
-      }`
+      const splitTreePathA = treePathA.split('/')
+      const parentPathA = splitTreePathA
+        .slice(0, splitTreePathA.length - 1)
+        .join('/')
 
-      const parentPathB = `${treePathB.split('/')[0]}/${
-        treePathB.split('/')[1]
-      }`
+      const splitTreePathB = treePathB.split('/')
+      const parentPathB = splitTreePathB
+        .slice(0, splitTreePathB.length - 1)
+        .join('/')
 
-      const nameA = treePathA.split('/')[treePathA.split('/').length - 1]
-      const nameB = treePathB.split('/')[treePathB.split('/').length - 1]
+      const nameA = splitTreePathA[splitTreePathA.length - 1]
+      const nameB = splitTreePathB[splitTreePathB.length - 1]
 
       if (parentPathA !== parentPathB) {
         return 0
@@ -121,20 +154,7 @@ export function getComponents(
 
       return treePathA > treePathB ? 1 : -1
     })
-    .map<SidebarComponent>(treePath => {
-      const schema = getComponentSchema(treePath)
-      const extension = pathOr<Partial<Extension>, Extension>(
-        {},
-        [treePath],
-        extensions
-      )
-
-      return {
-        isEditable: extension.composition !== 'children',
-        name: extensions[treePath].title || schema.title!,
-        treePath,
-      }
-    })
+    .map<SidebarComponent>(treePath => sidebarComponentMap[treePath])
 }
 
 export const getIsSitewide = (extensions: Extensions, editTreePath: string) => {
@@ -145,6 +165,25 @@ export const getIsSitewide = (extensions: Extensions, editTreePath: string) => {
       ['AFTER', 'AROUND', 'BEFORE'].includes(blockPath[1].role)) ||
     false
   )
+}
+
+export const hasContentPropsInSchema = (schema: ComponentSchema): boolean => {
+  if (schema.type === 'object') {
+    for (const prop in schema.properties) {
+      if (schema.properties.hasOwnProperty(prop)) {
+        const property = schema.properties[prop]
+        if (!property.isLayout) {
+          return true
+        } else if (property.type === 'object') {
+          const hasContent = hasContentPropsInSchema(property)
+          if (hasContent) {
+            return true
+          }
+        }
+      }
+    }
+  }
+  return false
 }
 
 export const getIsDefaultContent: (

--- a/react/components/EditorContainer/Sidebar/utils.ts
+++ b/react/components/EditorContainer/Sidebar/utils.ts
@@ -168,22 +168,17 @@ export const getIsSitewide = (extensions: Extensions, editTreePath: string) => {
 }
 
 export const hasContentPropsInSchema = (schema: ComponentSchema): boolean => {
-  if (schema.type === 'object') {
-    for (const prop in schema.properties) {
-      if (schema.properties.hasOwnProperty(prop)) {
-        const property = schema.properties[prop]
-        if (!property.isLayout) {
-          return true
-        } else if (property.type === 'object') {
-          const hasContent = hasContentPropsInSchema(property)
-          if (hasContent) {
-            return true
-          }
-        }
+  return (
+    schema.type === 'object' &&
+    Object.values(schema.properties || {}).some(property => {
+      if (
+        !property.isLayout ||
+        (property.type === 'object' && hasContentPropsInSchema(property))
+      ) {
+        return true
       }
-    }
-  }
-  return false
+    })
+  )
 }
 
 export const getIsDefaultContent: (

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -29,6 +29,7 @@ declare global {
     configurationsIds?: string[]
     content: object
     contentMapId?: string
+    hasContentSchema: boolean
     implementationIndex: number
     implements: string[]
     props: object

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -120,6 +120,7 @@ export const getExtension = (
     configurationsIds = [],
     content = {},
     contentMapId = '',
+    hasContentSchema = false,
     implementationIndex = 0,
     implements: extensionImplements = [],
     props = {},
@@ -138,6 +139,7 @@ export const getExtension = (
     configurationsIds,
     content,
     contentMapId,
+    hasContentSchema,
     implementationIndex,
     implements: extensionImplements,
     props: props || {},
@@ -183,7 +185,7 @@ export const getSchemaPropsOrContent = ({
   validate(propsOrContent)
   const dataFromSchema = validate.validatedData!.reduce(
     (acc: any, { value, format, dataPath, isLayout }: any) => {
-      if (isLayout) {
+      if (isLayout !== isContent) {
         return acc
       }
       if (IOMESSAGE_FORMAT_TYPE.includes(format) && messages) {
@@ -268,10 +270,11 @@ export const updateExtensionFromForm = ({
 
 const getIOMessageAjv = () => {
   const opts = {
+    nullable: true,
     shouldStoreValidSchema: true,
     useDefaults: true,
-    nullable: true,
   }
+
   const ajv = new Ajv(opts)
   const validationFunction = (value: string) => {
     return value.length >= 0


### PR DESCRIPTION
#### What problem is this solving?

Improvements to sidebar's list logic:
1. Show nested blocks with composition === 'children' if they are editable.
2. Check schema and hasContentSchema to see if blocks are clickable.
3. Cache some of the results on the iterations for performance reasons.
4. Fix sort logic

#### How should this be manually tested?

[Workspace](https://sidebar--instore.myvtex.com/admin/cms/storefront)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

[ch14316]