### PR TITLE
Add allErrors flag to ajv validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add allErrors to ajv validation
+
 ## [3.15.6] - 2019-07-03
 
 ### Fixed

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -268,6 +268,7 @@ export const updateExtensionFromForm = ({
 
 const getIOMessageAjv = () => {
   const opts = {
+    allErrors: true,
     nullable: true,
     shouldStoreValidSchema: true,
     useDefaults: true,


### PR DESCRIPTION
#### What problem is this solving?
i18n mapping is stopped when data is invalid

<!--- What is the motivation and context for this change? -->
i18n mapping and data validation are different things, this way we do continue to map i18n content even when data is invalid.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
