### PR TITLE
Add all IOMessage formats to i18nMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `RichText` type to i18n Mapping
+
 ## [3.15.7] - 2019-07-03
 
 ### Fixed

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -187,7 +187,7 @@ export const getSchemaPropsOrContent = ({
       if (isLayout) {
         return acc
       }
-      if (IOMESSAGE_FORMAT_TYPE.includes(format) && messages) {
+      if (IO_MESSAGE_FORMATS.includes(format) && messages) {
         const id =
           i18nMapping && i18nMapping[value] !== undefined
             ? i18nMapping[value]


### PR DESCRIPTION
#### What problem is this solving?
Displaying i18n mapping hash id when saving RichText content

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Edit any RichText content on
https://jey--alssports.myvtex.com/admin/cms/storefront

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
