### PR TITLE
Add support to uiSchema from JSONSchema dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support to uiSchema from JSONSchema dependencies
+
 ## [3.15.8] - 2019-07-08
 
 ### Fixed

--- a/react/__mocks__/vtex.render-runtime.ts
+++ b/react/__mocks__/vtex.render-runtime.ts
@@ -1,0 +1,2 @@
+export const global = {}
+export const Window = {}

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/utils.test.ts
@@ -1,0 +1,140 @@
+import { getUiSchema } from './utils'
+
+describe('getUiSchema', () => {
+  const mockComponents = {
+    'vtex.no-schema': {
+      schema: {},
+    },
+    'vtex.schema-with-dependencies': {
+      schema: {
+        dependencies: {
+          foo: {
+            oneOf: [
+              {
+                properties: {
+                  bar: { type: 'string', widget: { 'ui:widget': 'textarea' } },
+                  foo: {
+                    enum: ['0'],
+                  },
+                },
+                required: ['bar'],
+              },
+              {
+                properties: {
+                  baz: { type: 'string', widget: { 'ui:widget': 'IOMessage' } },
+                  foo: {
+                    enum: ['1'],
+                  },
+                },
+              },
+            ],
+          },
+        },
+        properties: {
+          foo: {
+            enum: ['0', '1'],
+          },
+        },
+        required: ['foo'],
+      },
+    },
+    'vtex.schema-with-nested-dependencies': {
+      schema: {
+        dependencies: {
+          foo: {
+            oneOf: [
+              {
+                dependencies: {
+                  bar: {
+                    oneOf: [
+                      {
+                        properties: {
+                          baar: {
+                            type: 'string',
+                            widget: { 'ui:widget': 'textarea' },
+                          },
+                          bar: { enum: ['0'] },
+                        },
+                      },
+                    ],
+                  },
+                },
+                properties: {
+                  bar: { enum: ['0'] },
+                  foo: {
+                    enum: ['0'],
+                  },
+                },
+                required: ['bar'],
+              },
+              {
+                properties: {
+                  baz: { type: 'string', widget: { 'ui:widget': 'IOMessage' } },
+                  foo: {
+                    enum: ['1'],
+                  },
+                },
+              },
+            ],
+          },
+        },
+        properties: {
+          foo: {
+            enum: ['0', '1'],
+          },
+        },
+        required: ['foo'],
+      },
+    },
+    'vtex.simple-schema': {
+      schema: {
+        properties: {
+          foo: {
+            properties: {
+              bar: {
+                widget: { 'ui:widget': 'textarea' },
+              },
+            },
+            type: 'object',
+          },
+        },
+      },
+    },
+  }
+
+  it('should get ui schema for dependencies', () => {
+    expect(
+      getUiSchema({}, mockComponents['vtex.schema-with-dependencies']
+        .schema as ComponentSchema)
+    ).toEqual({
+      bar: { 'ui:widget': 'textarea' },
+      baz: { 'ui:widget': 'IOMessage' },
+    })
+  })
+
+  it('should get ui schema for nested dependencies', () => {
+    expect(
+      getUiSchema({}, mockComponents['vtex.schema-with-nested-dependencies']
+        .schema as ComponentSchema)
+    ).toEqual({
+      baar: { 'ui:widget': 'textarea' },
+      baz: { 'ui:widget': 'IOMessage' },
+    })
+  })
+
+  it('should deal with empty schemas', () => {
+    expect(
+      getUiSchema({}, mockComponents['vtex.no-schema']
+        .schema as ComponentSchema)
+    ).toEqual({})
+  })
+
+  it('should get ui schema for simple schemas', () => {
+    expect(
+      getUiSchema({}, mockComponents['vtex.simple-schema']
+        .schema as ComponentSchema)
+    ).toEqual({
+      foo: { bar: { 'ui:widget': 'textarea' } },
+    })
+  })
+})

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/utils.test.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/utils.test.ts
@@ -103,38 +103,37 @@ describe('getUiSchema', () => {
   }
 
   it('should get ui schema for dependencies', () => {
-    expect(
-      getUiSchema({}, mockComponents['vtex.schema-with-dependencies']
-        .schema as ComponentSchema)
-    ).toEqual({
+    const uiSchema = {
       bar: { 'ui:widget': 'textarea' },
       baz: { 'ui:widget': 'IOMessage' },
-    })
+    }
+    const result = getUiSchema({}, mockComponents[
+      'vtex.schema-with-dependencies'
+    ].schema as ComponentSchema)
+    expect(result).toEqual(uiSchema)
   })
 
   it('should get ui schema for nested dependencies', () => {
-    expect(
-      getUiSchema({}, mockComponents['vtex.schema-with-nested-dependencies']
-        .schema as ComponentSchema)
-    ).toEqual({
+    const uiSchema = {
       baar: { 'ui:widget': 'textarea' },
       baz: { 'ui:widget': 'IOMessage' },
-    })
+    }
+    const result = getUiSchema({}, mockComponents[
+      'vtex.schema-with-nested-dependencies'
+    ].schema as ComponentSchema)
+    expect(result).toEqual(uiSchema)
   })
 
   it('should deal with empty schemas', () => {
-    expect(
-      getUiSchema({}, mockComponents['vtex.no-schema']
-        .schema as ComponentSchema)
-    ).toEqual({})
+    const result = getUiSchema({}, mockComponents['vtex.no-schema']
+      .schema as ComponentSchema)
+    expect(result).toEqual({})
   })
 
   it('should get ui schema for simple schemas', () => {
-    expect(
-      getUiSchema({}, mockComponents['vtex.simple-schema']
-        .schema as ComponentSchema)
-    ).toEqual({
-      foo: { bar: { 'ui:widget': 'textarea' } },
-    })
+    const uiSchema = { foo: { bar: { 'ui:widget': 'textarea' } } }
+    const result = getUiSchema({}, mockComponents['vtex.simple-schema']
+      .schema as ComponentSchema)
+    expect(result).toEqual(uiSchema)
   })
 })

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/utils.ts
@@ -1,4 +1,5 @@
-import { has, map, mergeDeepLeft, pickBy } from 'ramda'
+import traverse from 'json-schema-traverse'
+import { assocPath, mergeDeepLeft } from 'ramda'
 
 import {
   getComponentSchema,
@@ -17,7 +18,7 @@ import { GetSchemasArgs } from './typings'
  * @return {object} A object defining the complete `UiSchema` that matches all the schema
  *  properties.
  */
-const getUiSchema = (
+export const getUiSchema = (
   componentUiSchema: UISchema,
   componentSchema: ComponentSchema
 ): UISchema => {
@@ -37,45 +38,32 @@ const getUiSchema = (
    *
    * @param {object} properties The schema properties to be analysed.
    */
-  const getDeepUiSchema = (properties: any): UISchema => {
-    const deepProperties = pickBy(
-      property => has('properties', property),
-      properties
-    )
-    const itemsProperties = pickBy(
-      property => has('properties', property),
-      properties.items
-    )
 
-    return {
-      ...map(
-        (value: ComponentSchema) => value.widget,
-        pickBy(property => has('widget', property), properties)
-      ),
-      ...(deepProperties &&
-        map(property => getDeepUiSchema(property.properties), deepProperties)),
-      ...(itemsProperties &&
-        map(item => getDeepUiSchema(item), itemsProperties)),
+  const arrayAttrs = /(anyOf|oneOf|allOf|dependencies)(\/\d+|\/\w+)?/g
+  const noUISchemaProp = [
+    'definitions',
+    'properties',
+    'patternProperties',
+    'additionalProperties',
+  ]
+  let uiSchema = {}
+
+  const getWidget = (...args: any[]) => {
+    const [schema, JSONPointer] = args
+    if (schema.widget) {
+      const widgetPath = JSONPointer.replace(arrayAttrs, '')
+        .split('/')
+        .filter(
+          (pointer: string) => pointer && !noUISchemaProp.includes(pointer)
+        )
+      uiSchema = {
+        ...uiSchema,
+        ...assocPath(widgetPath, schema.widget, uiSchema),
+      }
     }
   }
 
-  const uiSchema = {
-    ...map(value => value.widget, pickBy(
-      property => has('widget', property),
-      componentSchema.properties as ComponentSchemaProperties
-    ) as { widget: any }),
-    ...map(property => getDeepUiSchema(property.properties), pickBy(
-      property => has('properties', property),
-      componentSchema.properties as ComponentSchemaProperties
-    ) as ComponentSchemaProperties),
-    ...map(
-      property => getDeepUiSchema(property),
-      pickBy<{}, ComponentSchemaProperties>(
-        property => has('items', property),
-        componentSchema.properties || {}
-      )
-    ),
-  }
+  traverse(componentSchema, getWidget)
 
   return mergeDeepLeft(uiSchema, componentUiSchema || {})
 }

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/utils.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/utils.ts
@@ -56,10 +56,7 @@ export const getUiSchema = (
         .filter(
           (pointer: string) => pointer && !noUISchemaProp.includes(pointer)
         )
-      uiSchema = {
-        ...uiSchema,
-        ...assocPath(widgetPath, schema.widget, uiSchema),
-      }
+      uiSchema = assocPath(widgetPath, schema.widget, uiSchema)
     }
   }
 

--- a/react/package.json
+++ b/react/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "exenv": "^1.2.2",
+    "json-schema-traverse": "^0.4.1",
     "lodash.debounce": "^4.0.8",
     "lodash.startcase": "^4.4.0",
     "lodash.throttle": "^4.1.1",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -269,7 +269,7 @@ declare global {
     [key: string]: ComponentSchema
   }
 
-  interface ComponentSchema {
+  interface ComponentSchema extends JSONSchema6 {
     type?: string
     title?: string
     description?: string

--- a/react/typings/json-schema-traverse.d.ts
+++ b/react/typings/json-schema-traverse.d.ts
@@ -1,0 +1,7 @@
+declare module 'json-schema-traverse' {
+  var traverse: (
+    schema: ComponentSchema,
+    opts: (...args: any[]) => any | void
+  ) => void
+  export = traverse
+}


### PR DESCRIPTION
#### What problem is this solving?
We were ignoring uiSchema definitions from JSONSchema dependencies

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

At https://jey3--storecomponents.myvtex.com/admin/cms/storefront
Edit the Carousel, add a new banner and select image-text as content-type, images widget should be the image-uploader widget.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
`User Notes`: Components with dynamic form were not displaying custom widgets.

**Previous:**
![Screen Shot 2019-07-11 at 16 04 49](https://user-images.githubusercontent.com/1594322/61077956-de18e800-a3f5-11e9-870f-7993a06a91f3.png)


**Current:** 
![Screen Shot 2019-07-11 at 16 01 45](https://user-images.githubusercontent.com/1594322/61077979-eec95e00-a3f5-11e9-8f7d-ec60ba00827a.png)
