### PR TITLE
Sidebar breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar position in smaller windows.
+
 ## [4.3.0] - 2019-07-16
 
 ### Changed

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -93,12 +93,9 @@ const EditorContainer: React.FC<Props> = ({
     [editMode, editExtensionPoint]
   )
 
-  useEffect(
-    () => {
-      highlightExtensionPoint(null)
-    },
-    [editMode]
-  )
+  useEffect(() => {
+    highlightExtensionPoint(null)
+  }, [editMode])
 
   const containerProps = useMemo(() => getContainerProps(viewport), [viewport])
   const isDevelopment = runtime && runtime.production === false
@@ -109,7 +106,7 @@ const EditorContainer: React.FC<Props> = ({
     <FormMetaProvider>
       <ModalProvider>
         <IframeNavigationController iframeRuntime={runtime} />
-        <div className="w-100 h-100 min-vh-100 flex flex-column flex-row-reverse-l flex-wrap-l bg-base bb bw1 b--muted-5">
+        <div className="w-100 h-100 min-vh-100 flex flex-row-reverse flex-wrap-l bg-base bb bw1 b--muted-5">
           {!storeEditMode && runtime && (
             <Sidebar
               highlightHandler={highlightExtensionPoint}


### PR DESCRIPTION
#### What problem is this solving?

Flex behavior on smaller viewports.

#### How should this be manually tested?

[Workspace](https://sidebarbreakpoint--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage
Before:

<img width="1023" alt="Screen Shot 2019-07-23 at 17 31 50" src="https://user-images.githubusercontent.com/10400340/61745444-fb43a400-ad6f-11e9-84c8-1dcf193fd042.png">

After:

<img width="979" alt="Screen Shot 2019-07-23 at 17 31 36" src="https://user-images.githubusercontent.com/10400340/61745458-00085800-ad70-11e9-92cc-24d8e18f3c72.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |
