### PR TITLE
Partial route save and title in "standard" pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- It is now possible to edit the title of contextless routes.
+
 ### Changed
 
 - Change title that is shown in pages list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Change title that is shown in pages list.
+- Send partial route data to be saved.
+
 ## [3.16.1] - 2019-07-16
 
 ### Fixed

--- a/react/components/admin/pages/Form/Form.tsx
+++ b/react/components/admin/pages/Form/Form.tsx
@@ -118,7 +118,7 @@ const Form: React.FunctionComponent<Props> = ({
     <form onSubmit={onSave}>
       <SectionTitle textId="admin/pages.admin.pages.form.details.title" />
       <Input
-        disabled={!isInfoEditable}
+        disabled={!!data.context}
         label={intl.formatMessage(messages.fieldTitle)}
         onChange={detailChangeHandlerGetter('title')}
         required

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -1,3 +1,4 @@
+import { diff } from 'deep-object-diff'
 import { RouteFormData } from 'pages'
 import PropTypes from 'prop-types'
 import { isEmpty } from 'ramda'
@@ -254,7 +255,18 @@ class FormContainer extends Component<Props, State> {
         routeId,
         title,
         uuid,
-      } = this.state.data
+      } = isNewRoute(this.props.initialData)
+        ? this.state.data
+        : {
+            ...(diff(this.props.initialData, this.state.data) as Partial<
+              RouteFormData
+            >),
+            declarer: this.state.data.declarer,
+            domain: this.state.data.domain,
+            path: this.state.data.path,
+            routeId: this.state.data.routeId,
+            uuid: this.state.data.uuid,
+          }
 
       this.setState({ isLoading: true }, async () => {
         try {
@@ -267,23 +279,30 @@ class FormContainer extends Component<Props, State> {
                 declarer,
                 domain,
                 interfaceId,
-                metaTags: {
-                  description: metaTagDescription,
-                  keywords: (metaTagKeywords || []).map(({ value }) => value),
-                },
-                pages: pages.map(page => {
-                  return {
-                    condition: {
-                      allMatches: page.condition.allMatches,
-                      id: page.condition.id || undefined,
-                      statements: formatStatements(page.condition.statements),
-                    },
-                    pageId: page.pageId || undefined,
-                    template: page.template,
-                  }
-                }),
+                metaTags:
+                  metaTagDescription || metaTagKeywords
+                    ? {
+                        description: metaTagDescription,
+                        keywords: (metaTagKeywords || []).map(
+                          ({ value }) => value
+                        ),
+                      }
+                    : undefined,
+                pages:
+                  pages &&
+                  pages.map(page => {
+                    return {
+                      condition: {
+                        allMatches: page.condition.allMatches,
+                        id: page.condition.id || undefined,
+                        statements: formatStatements(page.condition.statements),
+                      },
+                      pageId: page.pageId || undefined,
+                      template: page.template,
+                    }
+                  }),
                 path,
-                routeId: routeId || generateNewRouteId(interfaceId, path),
+                routeId: routeId || generateNewRouteId(interfaceId!, path!),
                 title,
                 uuid,
               },

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -302,7 +302,12 @@ class FormContainer extends Component<Props, State> {
                     }
                   }),
                 path,
-                routeId: routeId || generateNewRouteId(interfaceId!, path!),
+                routeId:
+                  routeId ||
+                  generateNewRouteId(
+                    interfaceId || this.state.data.interfaceId,
+                    path
+                  ),
                 title,
                 uuid,
               },

--- a/react/components/admin/pages/Form/typings.d.ts
+++ b/react/components/admin/pages/Form/typings.d.ts
@@ -36,7 +36,8 @@ interface ConditionsOnSaveRouteVariables {
 }
 
 export interface SaveRouteVariables {
-  route: Route
+  route: Partial<Route> &
+    Pick<Route, 'declarer' | 'domain' | 'path' | 'routeId'>
 }
 
 export interface DeleteRouteVariables {

--- a/react/components/admin/pages/Form/utils.ts
+++ b/react/components/admin/pages/Form/utils.ts
@@ -1,6 +1,6 @@
 import { DataProxy } from 'apollo-cache'
 import { RouteFormData } from 'pages'
-import { indexBy, pathOr, prop, values } from 'ramda'
+import { indexBy, pathOr, pickBy, prop, values } from 'ramda'
 import { ConditionsOperator } from 'vtex.styleguide'
 
 import Routes from '../../../../queries/Routes.graphql'
@@ -79,7 +79,14 @@ export const updateStoreAfterSave = (
 
       const newRoutesByPath = {
         ...routesByPath,
-        ...(savedRoutePath ? { [savedRoutePath]: savedRoute } : null),
+        ...(savedRoutePath
+          ? {
+              [savedRoutePath]: {
+                ...routesByPath[savedRoutePath],
+                ...pickBy(val => val != null, savedRoute || {}),
+              },
+            }
+          : null),
       }
       const newRoutes = values(newRoutesByPath)
 

--- a/react/components/admin/pages/utils.ts
+++ b/react/components/admin/pages/utils.ts
@@ -1,14 +1,27 @@
 import startCase from 'lodash.startcase'
 
 type NewRouteTypeArg = Pick<Route, 'uuid' | 'declarer'>
-export const isNewRoute = (route: NewRouteTypeArg) => !route.uuid && !route.declarer
+export const isNewRoute = (route: NewRouteTypeArg) =>
+  !route.uuid && !route.declarer
 
-type GetRouteTitleArg = Pick<Route, 'title' | 'blockId' | 'interfaceId'> & NewRouteTypeArg
+type GetRouteTitleArg = Pick<Route, 'title' | 'blockId' | 'interfaceId'> &
+  NewRouteTypeArg
+
 export const getRouteTitle = (route: GetRouteTitleArg) => {
-  if(isNewRoute(route)) {
-    return route.title || ''
+  const { blockId, declarer, interfaceId, title } = route
+
+  const nameFromInterfaceOrBlock = startCase(
+    blockId.split('#')[1] ||
+      interfaceId.split('.')[interfaceId.split('.').length - 1]
+  )
+
+  if (isNewRoute(route)) {
+    return title || ''
   }
-  return route.title || startCase(route.blockId.split('#')[1] || route.interfaceId.split('.')[route.interfaceId.split('.').length - 1])
+
+  return declarer
+    ? nameFromInterfaceOrBlock || title
+    : title || nameFromInterfaceOrBlock
 }
 
 export const isStoreRoute = (domain: Route['domain']) => domain === 'store'

--- a/react/package.json
+++ b/react/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
+    "deep-object-diff": "^1.1.0",
     "exenv": "^1.2.2",
     "json-schema-traverse": "^0.4.1",
     "lodash.debounce": "^4.0.8",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2662,6 +2662,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deep-object-diff@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
+  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"


### PR DESCRIPTION
#### What problem is this solving?

Enable editing title of pages that have *no* context attached, so users can define its own relevant SEO title.

#### How should this be manually tested?

[Workspace](https://partialroute--instore.myvtex.com/admin/cms/pages)

<!-- Your friendly Checklist/Reminders 📝 -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

<img width="300" alt="Screen Shot 2019-07-25 at 19 08 37" src="https://user-images.githubusercontent.com/10400340/61912116-a474d080-af0f-11e9-8cc4-7e5426633c15.png">

<img width="992" alt="Screen Shot 2019-07-25 at 19 08 59" src="https://user-images.githubusercontent.com/10400340/61912141-b22a5600-af0f-11e9-9976-e362699e8acc.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/idFxmiV2dayJEqzXaW/giphy.gif)
