### PR TITLE
Fix/content page fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Instructions to use content page.
+
+### Fixed
+
+- Avoid crash when trying to create a content page in a theme that doesn't support it.
+
 ## [4.6.0] - 2019-07-30
+
 ### Added
 
 - Store's locale switcher at topbar

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Pages Admin is a platform to dynamically edit a VTEX Store, making it possib
 ## Continuous Integrations
 
 ### Travis CI
+
 [![Build Status](https://travis-ci.org/vtex-apps/pages-editor.svg?branch=master)](https://travis-ci.org/vtex-apps/pages-editor)
 
 ## How to make your Component editable
@@ -74,8 +75,8 @@ static getSchema = ({numberOfBanners}) => {
   // Call's the function if the numberOfBanners its passed
   const generatedSchema = numberOfBanners && getRepeatedProperties(numberOfBanners)
 
-  /** 
-  * Returns a schema embedding the generated properties and the static property needed 
+  /**
+  * Returns a schema embedding the generated properties and the static property needed
   * to type the number of banners wanted.
   */
   return {
@@ -90,3 +91,7 @@ static getSchema = ({numberOfBanners}) => {
   }
 }
 ```
+
+## Custom Content Pages
+
+See [docs](https://github.com/vtex-apps/admin-pages/blob/master/docs/CONTENT_PAGES.md)

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -20,7 +20,7 @@
     "subSection": "onlinestore",
     "subSectionItems": [
       {
-        "labelId": "admin/pages.admin-menu-button.storefront",
+        "labelId": "admin/pages.admin-menu-button.storefront-smb",
         "path": "/admin/cms/storefront"
       },
       {

--- a/docs/CONTENT_PAGE.md
+++ b/docs/CONTENT_PAGE.md
@@ -1,4 +1,4 @@
-# VTEX Content Pages
+# VTEX Custom Content
 
 ## Description
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -2,6 +2,7 @@
   "admin/pages.admin-menu-button.pages": "admin/pages.admin-menu-button.pages",
   "admin/pages.admin-menu-button.storefront": "admin/pages.admin-menu-button.storefront",
   "admin/pages.admin-menu-button.content-pages": "admin/pages.admin.tabs.content-pages",
+  "admin/pages.admin-menu-button.storefront-smb": "admin/pages.admin-menu-button.storefront-smb",
   "admin/pages.admin.loading": "admin/pages.admin.loading",
   "admin/pages.admin.pages.form.button.cancel": "admin/pages.admin.pages.form.button.cancel",
   "admin/pages.admin.pages.form.button.delete": "admin/pages.admin.pages.form.button.delete",
@@ -254,7 +255,7 @@
   "admin/pages.admin.content.not-supported.title": "admin/pages.admin.content.not-supported.title",
   "admin/pages.admin.content.not-supported.description": "admin/pages.admin.content.not-supported.description",
   "admin/pages.admin.content.not-supported.action": "admin/pages.admin.content.not-supported.action",
-  
+
   "admin/pages.editor.settings.language": "admin/pages.editor.settings.language",
   "admin/pages.editor.locale.aa": "admin/pages.editor.locale.aa",
   "admin/pages.editor.locale.ab": "admin/pages.editor.locale.ab",

--- a/messages/context.json
+++ b/messages/context.json
@@ -251,6 +251,9 @@
   "admin/pages.admin.content.general.seo.page-title": "admin/pages.admin.content.general.seo.page-title",
   "admin/pages.admin.content.general.seo.description": "admin/pages.admin.content.general.seo.description",
   "admin/pages.admin.content.content.section-title": "admin/pages.admin.content.content.section-title",
+  "admin/pages.admin.content.not-supported.title": "admin/pages.admin.content.not-supported.title",
+  "admin/pages.admin.content.not-supported.description": "admin/pages.admin.content.not-supported.description",
+  "admin/pages.admin.content.not-supported.action": "admin/pages.admin.content.not-supported.action",
   
   "admin/pages.editor.settings.language": "admin/pages.editor.settings.language",
   "admin/pages.editor.locale.aa": "admin/pages.editor.locale.aa",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,7 @@
   "admin/pages.admin-menu-button.pages": "Pages",
   "admin/pages.admin-menu-button.storefront": "Storefront",
   "admin/pages.admin-menu-button.content-pages": "Content Pages",
+  "admin/pages.admin-menu-button.storefront-smb": "Storefront",
   "admin/pages.admin.loading": "Loading",
   "admin/pages.admin.pages.form.button.cancel": "Cancel",
   "admin/pages.admin.pages.form.button.delete": "Delete",
@@ -254,7 +255,7 @@
   "admin/pages.admin.content.not-supported.title": "This feature is not available :/",
   "admin/pages.admin.content.not-supported.description": "The theme installed in your store does not support the creation of content pages. If you need to create pages, choose another theme that supports this feature, or if you use a custom theme, ask the developer to follow the instructions in the link below.",
   "admin/pages.admin.content.not-supported.action": "See instructions",
-  
+
   "admin/pages.editor.settings.language": "Language",
   "admin/pages.editor.locale.aa": "Afar",
   "admin/pages.editor.locale.ab": "Abkhazian",

--- a/messages/en.json
+++ b/messages/en.json
@@ -251,6 +251,9 @@
   "admin/pages.admin.content.general.seo.page-title": "<Page title>",
   "admin/pages.admin.content.general.seo.description": "<The description is the text commonly used by Google to display text results from the second and third lines of the search results, just below the title>",
   "admin/pages.admin.content.content.section-title": "Content",
+  "admin/pages.admin.content.not-supported.title": "This feature is not available :/",
+  "admin/pages.admin.content.not-supported.description": "The theme installed in your store does not support the creation of content pages. If you need to create pages, choose another theme that supports this feature, or if you use a custom theme, ask the developer to follow the instructions in the link below.",
+  "admin/pages.admin.content.not-supported.action": "See instructions",
   
   "admin/pages.editor.settings.language": "Language",
   "admin/pages.editor.locale.aa": "Afar",

--- a/messages/en.json
+++ b/messages/en.json
@@ -253,7 +253,7 @@
   "admin/pages.admin.content.general.seo.description": "<The description is the text commonly used by Google to display text results from the second and third lines of the search results, just below the title>",
   "admin/pages.admin.content.content.section-title": "Content",
   "admin/pages.admin.content.not-supported.title": "This feature is not available :/",
-  "admin/pages.admin.content.not-supported.description": "The theme installed in your store does not support the creation of content pages. If you need to create pages, choose another theme that supports this feature, or if you use a custom theme, ask the developer to follow the instructions in the link below.",
+  "admin/pages.admin.content.not-supported.description": "The theme installed in your store does not support the creation of custom content pages. If you need to create pages, choose another theme that supports this feature, or if you use a custom theme, ask the developer to follow the instructions in the link below.",
   "admin/pages.admin.content.not-supported.action": "See instructions",
 
   "admin/pages.editor.settings.language": "Language",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,6 +2,7 @@
   "admin/pages.admin-menu-button.pages": "Páginas",
   "admin/pages.admin-menu-button.storefront": "Storefront",
   "admin/pages.admin-menu-button.content-pages": "Institucional",
+  "admin/pages.admin-menu-button.storefront-smb": "Escaparate",
   "admin/pages.admin.loading": "Cargando",
   "admin/pages.admin.pages.form.button.cancel": "Cancelar",
   "admin/pages.admin.pages.form.button.delete": "Borrar",
@@ -254,7 +255,7 @@
   "admin/pages.admin.content.not-supported.title": "Esta funcionalidad no está disponible :/",
   "admin/pages.admin.content.not-supported.description": "El tema instalado en su tienda no admite la creación de páginas de contenido. Si necesita crear páginas, elija otro tema que admita esta función, o si usa un tema personalizado, pídale al desarrollador que siga las instrucciones en el siguiente enlace.",
   "admin/pages.admin.content.not-supported.action": "Instrucciones",
-  
+
   "admin/pages.editor.settings.language": "Lengua",
   "admin/pages.editor.locale.aa": "Afar",
   "admin/pages.editor.locale.ab": "Abjasio",

--- a/messages/es.json
+++ b/messages/es.json
@@ -251,6 +251,9 @@
   "admin/pages.admin.content.general.seo.page-title": "<Título de la página>",
   "admin/pages.admin.content.general.seo.description": "<La descripción es el texto comúnmente utilizado por Google para mostrar los resultados de texto de la segunda y tercera línea de los resultados de búsqueda, justo debajo del título>",
   "admin/pages.admin.content.content.section-title": "Contenido",
+  "admin/pages.admin.content.not-supported.title": "Esta funcionalidad no está disponible :/",
+  "admin/pages.admin.content.not-supported.description": "El tema instalado en su tienda no admite la creación de páginas de contenido. Si necesita crear páginas, elija otro tema que admita esta función, o si usa un tema personalizado, pídale al desarrollador que siga las instrucciones en el siguiente enlace.",
+  "admin/pages.admin.content.not-supported.action": "Instrucciones",
   
   "admin/pages.editor.settings.language": "Lengua",
   "admin/pages.editor.locale.aa": "Afar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -251,6 +251,9 @@
   "admin/pages.admin.content.general.seo.page-title": "<Título da página>",
   "admin/pages.admin.content.general.seo.description": "<A descrição é o texto geralmente utilizado pelo Google para a exibição dos resultados de texto das segundas e terceiras linhas dos resultados de busca, logo abaixo do título>",
   "admin/pages.admin.content.content.section-title": "Conteúdo",
+  "admin/pages.admin.content.not-supported.title": "Funcionalidade não suportada :/",
+  "admin/pages.admin.content.not-supported.description": "O tema instalado na sua loja não suporta a criação de páginas institucionais. Caso necessite criar páginas, escolha algum outro tema que suporte essa funcionalidade ou, caso utilize algum tema personalizado, solicite ao desenvolvedor que siga as instruções indicadas no link abaixo.",
+  "admin/pages.admin.content.not-supported.action": "Ver instruções",
   
   "admin/pages.editor.settings.language": "Língua",
   "admin/pages.editor.locale.aa": "Afar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,7 +2,7 @@
   "admin/pages.admin-menu-button.pages": "Páginas",
   "admin/pages.admin-menu-button.storefront": "Storefront",
   "admin/pages.admin-menu-button.content-pages": "Institucional",
-  "admin/pages.admin-menu-button.storefront-smb": "Visual",
+  "admin/pages.admin-menu-button.storefront-smb": "Editor de layout",
   "admin/pages.admin.loading": "Carregando",
   "admin/pages.admin.pages.form.button.cancel": "Cancelar",
   "admin/pages.admin.pages.form.button.delete": "Deletar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,6 +2,7 @@
   "admin/pages.admin-menu-button.pages": "Páginas",
   "admin/pages.admin-menu-button.storefront": "Storefront",
   "admin/pages.admin-menu-button.content-pages": "Institucional",
+  "admin/pages.admin-menu-button.storefront-smb": "Visual",
   "admin/pages.admin.loading": "Carregando",
   "admin/pages.admin.pages.form.button.cancel": "Cancelar",
   "admin/pages.admin.pages.form.button.delete": "Deletar",
@@ -254,7 +255,7 @@
   "admin/pages.admin.content.not-supported.title": "Funcionalidade não suportada :/",
   "admin/pages.admin.content.not-supported.description": "O tema instalado na sua loja não suporta a criação de páginas institucionais. Caso necessite criar páginas, escolha algum outro tema que suporte essa funcionalidade ou, caso utilize algum tema personalizado, solicite ao desenvolvedor que siga as instruções indicadas no link abaixo.",
   "admin/pages.admin.content.not-supported.action": "Ver instruções",
-  
+
   "admin/pages.editor.settings.language": "Língua",
   "admin/pages.editor.locale.aa": "Afar",
   "admin/pages.editor.locale.ab": "Abcázio",

--- a/react/components/admin/institutional/Form/UnallowedWarning.tsx
+++ b/react/components/admin/institutional/Form/UnallowedWarning.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Button, EmptyState } from 'vtex.styleguide'
+
+const UnallowedWarning = () => (
+  <EmptyState
+    title={
+      <FormattedMessage
+        id="admin/pages.admin.content.not-supported.title"
+        defaultMessage="This feature is not available :/"
+      />
+    }
+  >
+    <FormattedMessage id="admin/pages.admin.content.not-supported.description">
+      {message => <p>{message}</p>}
+    </FormattedMessage>
+    <div className="pt5">
+      <Button
+        variation="secondary"
+        size="small"
+        href="https://github.com/vtex-apps/admin-pages/blob/next/react/components/admin/institutional/README.md"
+        target="_blank"
+      >
+        <FormattedMessage
+          id="admin/pages.admin.content.not-supported.action"
+          defaultMessage="See instructions"
+        />
+      </Button>
+    </div>
+  </EmptyState>
+)
+
+export default UnallowedWarning

--- a/react/components/admin/institutional/Form/UnallowedWarning.tsx
+++ b/react/components/admin/institutional/Form/UnallowedWarning.tsx
@@ -18,7 +18,7 @@ const UnallowedWarning = () => (
       <Button
         variation="secondary"
         size="small"
-        href="https://github.com/vtex-apps/admin-pages/blob/next/react/components/admin/institutional/README.md"
+        href="https://github.com/vtex-apps/admin-pages/blob/master/docs/CONTENT_PAGES.md"
         target="_blank"
       >
         <FormattedMessage

--- a/react/components/admin/institutional/Form/withContentContext.tsx
+++ b/react/components/admin/institutional/Form/withContentContext.tsx
@@ -1,18 +1,8 @@
 import { pathOr } from 'ramda'
 import * as React from 'react'
 import { Mutation, MutationFn, Query, QueryResult } from 'react-apollo'
-import { FormattedMessage } from 'react-intl'
 
-import { Button, EmptyState } from 'vtex.styleguide'
-
-import AvailableTemplates from '../../../../queries/AvailableTemplates.graphql'
-import ContentIOMessageQuery from '../../../../queries/ContentIOMessage.graphql'
-import DeleteRoute from '../../../../queries/DeleteRoute.graphql'
-import RouteQuery from '../../../../queries/Route.graphql'
-import SaveRoute from '../../../../queries/SaveRoute.graphql'
-
-import SaveContentMutation from '../../../EditorContainer/mutations/SaveContent'
-import ListContentQuery from '../../../EditorContainer/queries/ListContent'
+import UnallowedWarning from './UnallowedWarning'
 
 import {
   DeleteMutationResult,
@@ -25,7 +15,15 @@ import {
   updateStoreAfterSave,
 } from '../../pages/Form/utils'
 
+import SaveContentMutation from '../../../EditorContainer/mutations/SaveContent'
+import ListContentQuery from '../../../EditorContainer/queries/ListContent'
 import Loader from '../../../Loader'
+
+import AvailableTemplates from '../../../../queries/AvailableTemplates.graphql'
+import ContentIOMessageQuery from '../../../../queries/ContentIOMessage.graphql'
+import DeleteRoute from '../../../../queries/DeleteRoute.graphql'
+import RouteQuery from '../../../../queries/Route.graphql'
+import SaveRoute from '../../../../queries/SaveRoute.graphql'
 
 interface TemplateVariables {
   interfaceId: string
@@ -111,36 +109,7 @@ function withContentContext<T>(
                 )
 
                 if (!elegibleTemplates.length) {
-                  return (
-                    <div>
-                      <EmptyState
-                        title={
-                          <FormattedMessage
-                            id="admin/pages.admin.content.not-supported.title"
-                            defaultMessage="This feature is not available :/"
-                          />
-                        }
-                      >
-                        <p>
-                          <FormattedMessage id="admin/pages.admin.content.not-supported.description" />
-                        </p>
-                        <div className="pt5">
-                          <Button variation="secondary" size="small">
-                            <a
-                              className="link c-action-primary"
-                              href="https://github.com/vtex-apps/admin-pages/blob/next/react/components/admin/institutional/README.md"
-                              target="_blank"
-                            >
-                              <FormattedMessage
-                                id="admin/pages.admin.content.not-supported.action"
-                                defaultMessage="See instructions"
-                              />
-                            </a>
-                          </Button>
-                        </div>
-                      </EmptyState>
-                    </div>
-                  )
+                  return <UnallowedWarning />
                 }
 
                 const blockId = elegibleTemplates[0].id

--- a/react/components/admin/institutional/Form/withContentContext.tsx
+++ b/react/components/admin/institutional/Form/withContentContext.tsx
@@ -1,6 +1,9 @@
 import { pathOr } from 'ramda'
 import * as React from 'react'
 import { Mutation, MutationFn, Query, QueryResult } from 'react-apollo'
+import { FormattedMessage } from 'react-intl'
+
+import { Button, EmptyState } from 'vtex.styleguide'
 
 import AvailableTemplates from '../../../../queries/AvailableTemplates.graphql'
 import ContentIOMessageQuery from '../../../../queries/ContentIOMessage.graphql'
@@ -103,9 +106,44 @@ function withContentContext<T>(
                   return <Loader />
                 }
 
-                const blockId = dataTemplates!.availableTemplates.filter(
+                const elegibleTemplates = dataTemplates!.availableTemplates.filter(
                   (template: Template) => template.id !== interfaceId
-                )[0].id
+                )
+
+                if (!elegibleTemplates.length) {
+                  return (
+                    <div>
+                      <EmptyState
+                        title={
+                          <FormattedMessage
+                            id="admin/pages.admin.content.not-supported.title"
+                            defaultMessage="This feature is not available :/"
+                          />
+                        }
+                      >
+                        <p>
+                          <FormattedMessage id="admin/pages.admin.content.not-supported.description" />
+                        </p>
+                        <div className="pt5">
+                          <Button variation="secondary" size="small">
+                            <a
+                              className="link c-action-primary"
+                              href="https://github.com/vtex-apps/admin-pages/blob/next/react/components/admin/institutional/README.md"
+                              target="_blank"
+                            >
+                              <FormattedMessage
+                                id="admin/pages.admin.content.not-supported.action"
+                                defaultMessage="See instructions"
+                              />
+                            </a>
+                          </Button>
+                        </div>
+                      </EmptyState>
+                    </div>
+                  )
+                }
+
+                const blockId = elegibleTemplates[0].id
 
                 return (
                   <ListContentQuery

--- a/react/components/admin/institutional/README.md
+++ b/react/components/admin/institutional/README.md
@@ -4,7 +4,7 @@
 
 This is just an easier way to create content pages in your store. It provides an editor for you to create new routes and their content in a single form. You can edit the content using Storefront later as well.
 
-:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, and/or open issues with your feature requests.
 
 ## Usage
 
@@ -18,8 +18,6 @@ You must add `store.content` to your `blocks.json` just like the example below:
     "children": ["rich-text"]
   }
 ```
-
-:loudspeaker: **Disclaimer** Content pages won't be available if this block don't be added to your `blocks.json`.
 
 ## Continuous Integrations
 

--- a/react/components/admin/institutional/README.md
+++ b/react/components/admin/institutional/README.md
@@ -1,0 +1,28 @@
+# VTEX Content Pages
+
+## Description
+
+This is just an easier way to create content pages in your store. It provides an editor for you to create new routes and their content in a single form. You can edit the content using Storefront later as well.
+
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request
+
+## Usage
+
+You must add `store.content` to your `blocks.json` just like the example below:
+
+```json
+  "store.content": {
+    "children": ["flex-layout.row#content-body"]
+  },
+  "flex-layout.row#content-body": {
+    "children": ["rich-text"]
+  }
+```
+
+:loudspeaker: **Disclaimer** Content pages won't be available if this block don't be added to your `blocks.json`.
+
+## Continuous Integrations
+
+### Travis CI
+
+![Build Status](https://travis-ci.org/vtex-apps/pages-editor.svg?branch=master)](https://travis-ci.org/vtex-apps/pages-editor)

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -135,7 +135,7 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
-"@babel/helper-member-expression-to-functions@^7.5.5":
+"@babel/helper-member-expression-to-functions@^7.0.0", "@babel/helper-member-expression-to-functions@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz#1fb5b8ec4453a93c439ee9fe3aeea4a84b76b590"
   integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
@@ -191,7 +191,7 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-replace-supers@^7.5.5":
+"@babel/helper-replace-supers@^7.4.4", "@babel/helper-replace-supers@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz#f84ce43df031222d2bad068d2626cb5799c34bc2"
   integrity sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==
@@ -384,7 +384,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-block-scoping@^7.5.5":
+"@babel/plugin-transform-block-scoping@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz#a35f395e5402822f10d2119f6f8e045e3639a2ce"
   integrity sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==
@@ -392,7 +392,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.13"
 
-"@babel/plugin-transform-classes@^7.5.5":
+"@babel/plugin-transform-classes@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz#d094299d9bd680a14a2a0edae38305ad60fb4de9"
   integrity sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==
@@ -523,7 +523,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-object-super@^7.5.5":
+"@babel/plugin-transform-object-super@^7.2.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz#c70021df834073c65eb613b8679cc4a381d1a9f9"
   integrity sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==


### PR DESCRIPTION
#### What problem is this solving?
Not all themes support content pages for now. This PR avoid page crash and add instructions to make a theme support content pages.

#### How should this be manually tested?
https://augusto--gcqa.mygocommerce.com/admin/cms/content/

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
<img width="1792" alt="Screen Shot 2019-07-29 at 14 19 02" src="https://user-images.githubusercontent.com/7659279/62069179-1306a680-b20e-11e9-8d59-e7cd0b02c1e5.png">


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
