### PR TITLE
Fix the usage of wrong tree paths in sitewide blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Content edition bug due to the usage of wrong tree paths in sitewide blocks.
+
 ## [4.8.0] - 2019-08-27
 
 ### Added

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -41,9 +41,9 @@ interface Props {
   queryData?: ListContentData
   refetch: ListContentQueryResult['refetch']
   saveContent: SaveContentMutationFn
+  serverTreePath: string
   showToast: ToastConsumerFunctions['showToast']
   template: string
-  treePath: string
 }
 
 interface State {
@@ -102,9 +102,12 @@ class ConfigurationList extends React.Component<Props, State> {
   public constructor(props: Props) {
     super(props)
 
-    const { iframeRuntime, intl, modal, queryData, treePath } = props
+    const { editor, iframeRuntime, intl, modal, queryData } = props
 
-    const extension = getExtension(treePath, iframeRuntime.extensions)
+    const extension = getExtension(
+      editor.editTreePath,
+      iframeRuntime.extensions
+    )
 
     this.component = extension.component
 
@@ -229,10 +232,10 @@ class ConfigurationList extends React.Component<Props, State> {
   private getNewActiveExtension = (
     queryResult: ApolloQueryResult<ListContentData>
   ) => {
-    const { iframeRuntime, treePath } = this.props
+    const { editor, iframeRuntime } = this.props
 
     const partialNewActiveExtension = getExtension(
-      treePath,
+      editor.editTreePath,
       iframeRuntime.extensions
     )
 
@@ -281,7 +284,7 @@ class ConfigurationList extends React.Component<Props, State> {
   }
 
   private handleContentBack = async () => {
-    const { formMeta, iframeRuntime, treePath } = this.props
+    const { editor, formMeta, iframeRuntime } = this.props
 
     this.handleConfigurationClose()
 
@@ -290,7 +293,7 @@ class ConfigurationList extends React.Component<Props, State> {
         data: this.activeExtension.content,
         isContent: true,
         runtime: iframeRuntime,
-        treePath,
+        treePath: editor.editTreePath,
       })
     }
   }
@@ -329,7 +332,7 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleConfigurationDeletion = async (
     configuration: ExtensionConfiguration
   ) => {
-    const { editor, iframeRuntime, intl, template, treePath } = this.props
+    const { editor, iframeRuntime, intl, serverTreePath, template } = this.props
 
     editor.setIsLoading(true)
 
@@ -341,7 +344,7 @@ class ConfigurationList extends React.Component<Props, State> {
           contentId: configuration.contentId,
           pageContext: iframeRuntime.route.pageContext,
           template,
-          treePath,
+          treePath: serverTreePath,
         },
       })
 
@@ -378,9 +381,9 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleConfigurationOpen = async (
     newConfiguration: ExtensionConfiguration
   ) => {
-    const { editor, iframeRuntime, intl, showToast, treePath } = this.props
+    const { editor, iframeRuntime, intl, showToast } = this.props
 
-    if (!treePath) {
+    if (!editor.editTreePath) {
       return
     }
 
@@ -393,8 +396,8 @@ class ConfigurationList extends React.Component<Props, State> {
 
     editor.setIsLoading(true)
 
-    await iframeRuntime.updateExtension(treePath, {
-      ...iframeRuntime.extensions[treePath],
+    await iframeRuntime.updateExtension(editor.editTreePath, {
+      ...iframeRuntime.extensions[editor.editTreePath],
       component: this.component,
       content: formData,
     })
@@ -440,8 +443,8 @@ class ConfigurationList extends React.Component<Props, State> {
       modal,
       iframeRuntime,
       saveContent,
+      serverTreePath,
       template,
-      treePath,
     } = this.props
 
     if (editor.getIsLoading() || !this.state.configuration) {
@@ -478,7 +481,7 @@ class ConfigurationList extends React.Component<Props, State> {
     }
 
     const blockId = path<string>(
-      ['extensions', treePath || '', 'blockId'],
+      ['extensions', editor.editTreePath || '', 'blockId'],
       iframeRuntime
     )
 
@@ -491,7 +494,7 @@ class ConfigurationList extends React.Component<Props, State> {
           configuration,
           lang: iframeRuntime.culture.locale,
           template,
-          treePath,
+          treePath: serverTreePath,
         },
       })
 
@@ -531,7 +534,7 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleFormChange: FormProps<{
     formData: object
   }>['onChange'] = event => {
-    const { formMeta, iframeRuntime, treePath } = this.props
+    const { editor, formMeta, iframeRuntime } = this.props
 
     if (
       this.state.formData &&
@@ -548,7 +551,7 @@ class ConfigurationList extends React.Component<Props, State> {
         data: event.formData,
         isContent: true,
         runtime: iframeRuntime,
-        treePath,
+        treePath: editor.editTreePath,
       })
     }
   }
@@ -582,17 +585,23 @@ class ConfigurationList extends React.Component<Props, State> {
   }
 
   private refetchConfigurations = async () => {
-    const { iframeRuntime, refetch, template, treePath } = this.props
+    const {
+      editor,
+      iframeRuntime,
+      refetch,
+      serverTreePath,
+      template,
+    } = this.props
 
-    if (!treePath) {
+    if (!editor.editTreePath) {
       return undefined
     }
 
     return await refetch({
-      blockId: iframeRuntime.extensions[treePath].blockId,
+      blockId: iframeRuntime.extensions[editor.editTreePath].blockId,
       pageContext: iframeRuntime.route.pageContext,
       template,
-      treePath,
+      treePath: serverTreePath,
     })
   }
 

--- a/react/components/EditorContainer/Sidebar/Content.tsx
+++ b/react/components/EditorContainer/Sidebar/Content.tsx
@@ -83,7 +83,7 @@ const Content = (props: Props) => {
     ? '*'
     : iframeRuntime.pages[iframeRuntime.page].blockId
 
-  const adaptedTreePath = isSitewide
+  const serverTreePath = isSitewide
     ? getSitewideTreePath(editTreePath)
     : editTreePath
 
@@ -95,7 +95,7 @@ const Content = (props: Props) => {
             blockId,
             pageContext: iframeRuntime.route.pageContext,
             template,
-            treePath: adaptedTreePath,
+            treePath: serverTreePath,
           }}
         >
           {({ data, loading, refetch }) => (
@@ -118,9 +118,9 @@ const Content = (props: Props) => {
                         queryData={data}
                         refetch={refetch}
                         saveContent={saveContent}
+                        serverTreePath={serverTreePath}
                         showToast={showToast}
                         template={template}
-                        treePath={adaptedTreePath}
                       />
                     )
                   }


### PR DESCRIPTION
#### What problem is this solving?
Fix the usage of wrong tree paths in sitewide blocks.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://fixsitewideblockstreepath--storecomponents.myvtex.com/admin/cms/storefront)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

1. Header => Notification bar;
2. Footer => Menu => News;
3. Any sitewide block :)

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

N/A.

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3o7TKEP6YngkCKFofC/giphy.gif)
