### PR TITLE
Fix component form state stack handling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Array item editing's state stack logic.
+
 ## [4.10.0] - 2019-08-29
 
 ### Added

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/hooks.ts
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/hooks.ts
@@ -8,9 +8,9 @@ export function useComponentFormStateStack() {
   const stack = useRef<ComponentFormState[]>([])
 
   function popComponentFormState() {
-    const newState = stack.current.pop()
+    stack.current.pop()
 
-    setComponentFormState(newState)
+    setComponentFormState(stack.current[stack.current.length - 1])
   }
 
   function pushComponentFormState(state: ComponentFormState) {


### PR DESCRIPTION
#### What problem is this solving?

The component form state stack's `pop` was treating the popped state as the new active one. However, the active state should always be the one at the top of the stack.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://fixbannerediting--storecomponents.myvtex.com/admin/cms/storefront)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Open and close a Carousel configuration.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |