### PR TITLE
Add ColorPicker Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- ColorPicker widget.
+
 ## [4.10.2] - 2019-09-02
 
 ### Added

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/Form.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/Form.tsx
@@ -14,6 +14,7 @@ import Radio from '../../../form/Radio'
 import RichText from '../../../form/RichText'
 import TextArea from '../../../form/TextArea'
 import Toggle from '../../../form/Toggle'
+import ColorPicker from '../../../form/ColorPicker'
 import { FormDataContainer } from '../typings'
 
 export const widgets: Record<string, Widget> = {
@@ -24,6 +25,7 @@ export const widgets: Record<string, Widget> = {
   RichText,
   SelectWidget: Dropdown as Widget,
   TextareaWidget: TextArea,
+  ColorPickerWidget: ColorPicker,
   'image-uploader': (ImageUploader as unknown) as Widget,
 }
 

--- a/react/components/form/ColorPicker.tsx
+++ b/react/components/form/ColorPicker.tsx
@@ -1,0 +1,92 @@
+import { JSONSchema6Type } from 'json-schema'
+import React, { Component, Fragment } from 'react'
+import { InjectedIntlProps, injectIntl } from 'react-intl'
+import { WidgetProps } from 'react-jsonschema-form'
+import { formatIOMessage } from 'vtex.native-types'
+import { ColorPicker as StyleguideColorPicker} from 'vtex.styleguide'
+
+interface Props extends InjectedIntlProps {
+  label?: string
+  name?: string
+  schema?: {
+    enumNames?: string[]
+  }
+}
+
+interface State {
+  value?: JSONSchema6Type,
+  color: {hex: String},
+  history: any
+}
+
+type ColorProps = Props & WidgetProps
+
+class ColorPicker extends Component<ColorProps, State> {
+  public static defaultProps = {
+    value: "#FFFFFF"
+  }
+
+  public constructor(props: ColorProps) {
+    super(props)
+
+    let color = props.value
+    var isColor  = /^#[0-9A-F]{6}$/i.test(props.value)
+
+
+    if(!isColor){
+      color = "#FFFFFF"
+    }
+
+    console.log(props, color);
+
+    this.state = {
+      color:{ hex: color},
+      history: []
+    }
+  }
+
+  public render() {
+    //const { id, intl, label, name, schema } = this.props
+    const { intl, label } = this.props
+
+    return (
+      <Fragment>
+        <style dangerouslySetInnerHTML={{__html: `
+          div#sidebar-vtex-editor, nav#admin-sidebar {width: 22em;}
+          .adminpages-colorpicker .options-container{position:relative}
+        `}} />
+
+        <span className="dib mb3 w-100">
+          {formatIOMessage({ id: label, intl })}
+        </span>
+
+        <div className="adminpages-colorpicker">
+
+        <StyleguideColorPicker
+          color={this.state.color}
+          colorHistory={this.state.history}
+          onChange={(color: String) =>
+            this.handleSelection(color)
+          }
+        />
+
+        </div>
+
+      </Fragment>
+    )
+  }
+
+  private handleSelection = (
+    color:any|never
+  ) => {
+    let { history } = this.state
+  
+    this.setState({ color, history: [...history, color]  })
+    
+
+    this.props.onChange(color.hex)
+  }
+}
+
+
+export default injectIntl(ColorPicker)


### PR DESCRIPTION
#### What problem is this solving?

Add a new Color Picker Widget to page editor. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

https://reviews--webimpacto.myvtex.com/admin/cms/site-editor/test-producto-soap/p

In the second row, admin/editor.rating.title component configuration. 

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/16488733/64155534-405cfa80-ce33-11e9-8bed-59ac3dcebc65.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->

|       | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->


