### PR TITLE
Fix: highlight overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Where `__setHighlightTreePath` was typed: deleted old interface and add it to `Window` interface.
+
+### Fixed
+
+- Issue when hovering over an element that wasn't in the DOM, `HighlightOverlay` made the iframe height grow indefinitely.
+
 ## [4.12.1] - 2019-09-12
 
 ## Changed

--- a/react/HighlightOverlay.tsx
+++ b/react/HighlightOverlay.tsx
@@ -116,11 +116,11 @@ export default class HighlightOverlay extends Component<Props, State> {
       `[data-extension-point="${highlightTreePath}"]`
     )
 
-    const provider = document.querySelector('.render-provider')
+    const provider = document.querySelector<HTMLDivElement>('.render-provider')
 
     const iframeBody = document.querySelector('body')
 
-    if (!highlightTreePath || !elements || !provider) {
+    if (!highlightTreePath || elements.length === 0 || !provider) {
       return
     }
 

--- a/react/HighlightOverlay.tsx
+++ b/react/HighlightOverlay.tsx
@@ -70,7 +70,7 @@ export default class HighlightOverlay extends Component<Props, State> {
       highlightTreePath: props.highlightTreePath,
     }
 
-    const highlightableWindow = window as HighlightableWindow
+    const highlightableWindow = window
 
     if (canUseDOM) {
       highlightableWindow.__setHighlightTreePath = (newState: State) => {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -263,10 +263,6 @@ declare global {
     contentWindow: ContentWindow | null
   }
 
-  interface HighlightableWindow extends Window {
-    __setHighlightTreePath: (HighlightOverlayState) => void
-  }
-
   interface ComponentSchemaProperties {
     [key: string]: ComponentSchema
   }
@@ -289,6 +285,7 @@ declare global {
       messages: Record<string, string>,
       shouldUpdateRuntime: boolean
     ) => Promise<void>
+    __setHighlightTreePath: (HighlightOverlayState) => void
   }
 
   interface AdminContext {


### PR DESCRIPTION
#### What problem is this solving?

HighlightOverlay makes the iframe height bigger when hovering over a component that isn't in the DOM.

#### How should this be manually tested?

[Workspace](https://fixhover--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/xT0GqtpF1NWd9VbstO/giphy.gif)
