### PR TITLE
Replace i18n editing logic to not use addMessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Replace the way i18n fields updates are handled with a (somewhat hacky) solution that doesn't use Runtime's `addMessages`.
+
+### Fixed
+
+- Some i18n editing inconsistencies.
+
 ## [4.12.2] - 2019-09-13
 
 ### Changed

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
@@ -118,10 +118,9 @@ const ComponentEditor: React.FunctionComponent<Props> = ({
         >
           <Form
             formContext={{
-              isLayoutMode: editor.mode === 'layout',
-              messages: iframeRuntime.messages,
               currentDepth,
               componentFormState,
+              isLayoutMode: editor.mode === 'layout',
               popComponentFormState,
               pushComponentFormState,
             }}

--- a/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ComponentEditor/index.tsx
@@ -118,7 +118,6 @@ const ComponentEditor: React.FunctionComponent<Props> = ({
         >
           <Form
             formContext={{
-              addMessages: iframeRuntime.addMessages,
               isLayoutMode: editor.mode === 'layout',
               messages: iframeRuntime.messages,
               currentDepth,

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -1,7 +1,7 @@
 import { ApolloQueryResult } from 'apollo-client'
 import { JSONSchema6 } from 'json-schema'
 import throttle from 'lodash/throttle'
-import { clone, equals, isEmpty, path } from 'ramda'
+import { clone, equals, path } from 'ramda'
 import React from 'react'
 import { defineMessages, injectIntl } from 'react-intl'
 import { FormProps } from 'react-jsonschema-form'
@@ -315,10 +315,6 @@ class ConfigurationList extends React.Component<Props, State> {
             modal.close()
           }
 
-          if (!isEmpty(formMeta.getI18nMapping())) {
-            formMeta.clearI18nMapping()
-          }
-
           editor.setIsLoading(false)
         }
       )
@@ -439,7 +435,6 @@ class ConfigurationList extends React.Component<Props, State> {
   private handleConfigurationSave = async () => {
     const {
       editor,
-      formMeta,
       modal,
       iframeRuntime,
       saveContent,
@@ -451,11 +446,7 @@ class ConfigurationList extends React.Component<Props, State> {
       return
     }
 
-    const i18nMapping = formMeta.getI18nMapping()
-
     const content = getSchemaPropsOrContent({
-      i18nMapping,
-      messages: iframeRuntime.messages,
       propsOrContent: this.state.formData,
       schema: this.componentSchema,
     })

--- a/react/components/EditorContainer/Sidebar/FormMetaContext.tsx
+++ b/react/components/EditorContainer/Sidebar/FormMetaContext.tsx
@@ -3,15 +3,6 @@ import React, { Component, createContext, useContext } from 'react'
 import { FormMetaContext as FormMetaContextT } from './typings'
 
 const defaultExternalState: FormMetaContextT = {
-  addToI18nMapping: () => {
-    return
-  },
-  clearI18nMapping: () => {
-    return
-  },
-  getI18nMapping: () => {
-    return {}
-  },
   getWasModified: () => {
     return false
   },
@@ -27,7 +18,6 @@ export const useFormMetaContext = () => useContext(FormMetaContext)
 export const FormMetaConsumer = FormMetaContext.Consumer
 
 interface State extends FormMetaContextT {
-  i18nMapping: Record<string, string>
   isLoading: boolean
   wasModified: boolean
 }
@@ -38,11 +28,7 @@ export class FormMetaProvider extends Component<{}, State> {
 
     this.state = {
       ...defaultExternalState,
-      addToI18nMapping: this.addToI18nMapping,
-      clearI18nMapping: this.clearI18nMapping,
-      getI18nMapping: this.getI18nMapping,
       getWasModified: this.getWasModified,
-      i18nMapping: {},
       isLoading: false,
       setWasModified: this.setWasModified,
       wasModified: false,
@@ -56,19 +42,6 @@ export class FormMetaProvider extends Component<{}, State> {
       </FormMetaContext.Provider>
     )
   }
-
-  private addToI18nMapping: State['addToI18nMapping'] = newEntry => {
-    this.setState(prevState => ({
-      ...prevState,
-      i18nMapping: { ...prevState.i18nMapping, ...newEntry },
-    }))
-  }
-
-  private clearI18nMapping: State['clearI18nMapping'] = () => {
-    this.setState({ i18nMapping: {} })
-  }
-
-  private getI18nMapping: State['getI18nMapping'] = () => this.state.i18nMapping
 
   private getWasModified: State['getWasModified'] = () => this.state.wasModified
 

--- a/react/components/EditorContainer/Sidebar/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/typings.d.ts
@@ -1,7 +1,4 @@
 export interface FormMetaContext {
-  addToI18nMapping: (newEntry: Record<string, string>) => void
-  clearI18nMapping: () => void
-  getI18nMapping: () => Record<string, string>
   getWasModified: () => boolean
   setWasModified: (newValue: boolean, callback?: () => void) => void
 }

--- a/react/components/form/BaseInput.tsx
+++ b/react/components/form/BaseInput.tsx
@@ -5,7 +5,7 @@ import { Input } from 'vtex.styleguide'
 
 import { CustomWidgetProps } from './typings'
 
-interface Props extends CustomWidgetProps, InjectedIntlProps {
+interface Props extends CustomWidgetProps<HTMLInputElement>, InjectedIntlProps {
   label: string
   max?: number
   min?: number
@@ -41,9 +41,8 @@ const BaseInput: React.FunctionComponent<Props> = props => {
 
   const currentError = rawErrors && rawErrors[0]
 
-  const onChange = ({
-    target: { value: inputValue },
-  }: React.ChangeEvent<HTMLInputElement>) => props.onChange(inputValue || '')
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    props.onChange(event.target.value || '', event.target)
 
   return (
     <Input

--- a/react/components/form/I18nInput.tsx
+++ b/react/components/form/I18nInput.tsx
@@ -1,9 +1,6 @@
-import debounce from 'lodash/debounce'
 import React from 'react'
-import { generate as generateUuid } from 'short-uuid'
 
-import { translateMessage } from '../../utils/components'
-import { useFormMetaContext } from '../EditorContainer/Sidebar/FormMetaContext'
+import { appendInvisibleCharacter } from '../../utils/components'
 
 import BaseInput from './BaseInput'
 import TextArea from './TextArea'
@@ -13,82 +10,57 @@ interface Props extends CustomWidgetProps {
   isTextarea?: boolean
 }
 
-const I18nInput: React.FunctionComponent<Props> = props => {
-  const {
-    addToI18nMapping,
-    getI18nMapping,
-    getWasModified,
-    setWasModified,
-  } = useFormMetaContext()
+/*
+ * While there isn't currently an efficient way to update the inner Runtime's
+ * intl, this component uses the IOMessage's fallback behavior to modify i18n
+ * properties.
+ *
+ * Since the value actually represents an i18n key, typing in the name of an
+ * existing one would cause the block to render the corresponding intl string.
+ *
+ * In order to prevent that, this component adds an invisible character after
+ * the input value, so it will (probably) never match an i18n key. The
+ * invisible character is removed once the form is submitted, before being sent
+ * to the server.
+ */
 
-  const isValueI18nKey = React.useMemo(
-    () => typeof props.formContext.messages[props.value] !== 'undefined',
-    [props.formContext.messages, props.value]
-  )
+const I18nInput: React.FunctionComponent<Props> = ({
+  isTextarea,
+  onChange,
+  value,
+  ...commonProps
+}) => {
+  const [localValue, setLocalValue] = React.useState(value)
 
-  const i18nKey = React.useMemo(() => {
-    if (isValueI18nKey) {
-      return props.value
-    }
-
-    return 'store/' + generateUuid()
-  }, [isValueI18nKey, props.value])
-
-  const initialValue = React.useMemo(
-    () =>
-      isValueI18nKey
-        ? translateMessage({
-            dictionary: props.formContext.messages,
-            id: i18nKey,
-          })
-        : props.value,
-    [i18nKey, isValueI18nKey, props.formContext.messages, props.value]
-  )
-
-  const [value, setValue] = React.useState(initialValue)
-
-  const mappedI18nKey = React.useMemo(generateUuid, [])
-
-  const updateIframeValue = React.useMemo(
-    () =>
-      debounce((newValue: string) => {
-        const i18nMapping = getI18nMapping()
-
-        if (i18nMapping[i18nKey] === undefined) {
-          addToI18nMapping({ [i18nKey]: mappedI18nKey })
-
-          props.onChange(mappedI18nKey)
-        }
-
-        props.formContext.addMessages({
-          [mappedI18nKey]: newValue,
-        })
-      }, 200),
-    [addToI18nMapping, getI18nMapping, i18nKey, mappedI18nKey, props]
-  )
-
-  const handleChange = React.useCallback(
-    (newValue: string) => {
-      const wasModified = getWasModified()
-
-      updateIframeValue(newValue)
-
-      if (!wasModified) {
-        setWasModified(true)
+  const safeOnChange: CustomWidgetProps<
+    HTMLInputElement | HTMLTextAreaElement
+  >['onChange'] = React.useCallback(
+    (newValue, target) => {
+      if (typeof newValue !== 'string' || !target) {
+        return
       }
 
-      setValue(newValue)
+      let cursorPosition = target.selectionStart
+
+      // Appends an invisible character to the input value. For more
+      // information, please read the comment above this component.
+      onChange(appendInvisibleCharacter(newValue))
+
+      setLocalValue(newValue)
+
+      // Prevents the cursor from jumping around
+      target.selectionStart = cursorPosition
     },
-    [getWasModified, setWasModified, updateIframeValue]
+    [onChange]
   )
 
   const finalProps = {
-    ...props,
-    onChange: handleChange,
-    value,
+    ...commonProps,
+    onChange: safeOnChange,
+    value: localValue,
   }
 
-  if (props.isTextarea) {
+  if (isTextarea) {
     return <TextArea {...finalProps} />
   }
 

--- a/react/components/form/TextArea.tsx
+++ b/react/components/form/TextArea.tsx
@@ -5,7 +5,7 @@ import { Textarea } from 'vtex.styleguide'
 
 import { CustomWidgetProps } from './typings'
 
-type Props = CustomWidgetProps & InjectedIntlProps
+type Props = CustomWidgetProps<HTMLTextAreaElement> & InjectedIntlProps
 
 const TextArea: React.FunctionComponent<Props> = ({
   disabled,
@@ -32,7 +32,7 @@ const TextArea: React.FunctionComponent<Props> = ({
 
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(event.target.value || '')
+      onChange(event.target.value || '', event.target)
     },
     [onChange]
   )

--- a/react/components/form/typings.d.ts
+++ b/react/components/form/typings.d.ts
@@ -1,11 +1,11 @@
 import { WidgetProps } from 'react-jsonschema-form'
 
-export interface CustomWidgetProps extends WidgetProps {
+export interface CustomWidgetProps<T = unknown> extends WidgetProps {
   formContext: {
-    addMessages: RenderContext['addMessages']
     messages: RenderContext['messages']
     isLayout: boolean
   }
+  onChange: (value: unknown, target?: React.ChangeEvent<T>['target']) => void
   rawErrors?: string[]
   schema: WidgetProps['schema'] & {
     disabled?: boolean

--- a/react/package.json
+++ b/react/package.json
@@ -43,7 +43,6 @@
     "react-sortable-hoc": "^1.9.1",
     "react-spring": "^8.0.18",
     "react-transition-group": "^4.2.2",
-    "short-uuid": "^3.1.1",
     "url-parse": "^1.4.3",
     "vtex.ajv": "^6.10.4"
   },

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -16,6 +16,7 @@ export const RICHTEXT_FORMAT_TYPE = 'RichText'
 export const IO_MESSAGE_FORMATS = [IOMESSAGE_FORMAT_TYPE, RICHTEXT_FORMAT_TYPE]
 
 const INVISIBLE_CHARACTER = '\u200b'
+const INVISIBLE_CHARACTERS_REGEX = new RegExp(INVISIBLE_CHARACTER, 'g')
 
 const reduceProperties = (isContent: boolean) => (
   acc: ComponentSchemaProperties,
@@ -288,15 +289,8 @@ const keepTheBlanks = (
 export const appendInvisibleCharacter = (text: string) =>
   text + INVISIBLE_CHARACTER
 
-const removeInvisibleCharacter = (text: string) => {
-  const lastIndex = text.length - 1
-
-  if (text[lastIndex] !== INVISIBLE_CHARACTER) {
-    return text
-  }
-
-  return text.slice(0, lastIndex)
-}
+const removeInvisibleCharacters = (text: string) =>
+  text.replace(INVISIBLE_CHARACTERS_REGEX, '')
 
 export const getImplementation = (component: string) => {
   return global.__RENDER_8_COMPONENTS__[component]
@@ -329,9 +323,9 @@ export const getSchemaPropsOrContent = ({
             id: value,
           })
         } else {
-          // Removes the invisible character from i18n fields. For more
+          // Removes invisible characters from i18n fields. For more
           // information, please check the I18nInput widget.
-          adaptedValue = removeInvisibleCharacter(value)
+          adaptedValue = removeInvisibleCharacters(value)
         }
 
         return { ...acc, ...assocPath(dataPath, adaptedValue, acc) }

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -15,6 +15,8 @@ export const IOMESSAGE_FORMAT_TYPE = 'IOMessage'
 export const RICHTEXT_FORMAT_TYPE = 'RichText'
 export const IO_MESSAGE_FORMATS = [IOMESSAGE_FORMAT_TYPE, RICHTEXT_FORMAT_TYPE]
 
+const INVISIBLE_CHARACTER = '\u200b'
+
 const reduceProperties = (isContent: boolean) => (
   acc: ComponentSchemaProperties,
   [propertyName, property]: [string, ComponentSchema]
@@ -181,7 +183,7 @@ export const getIframeImplementation = (component: string | null) => {
   return iframeRenderComponents && iframeRenderComponents[component]
 }
 
-export const translateMessage = ({
+const translateMessage = ({
   dictionary,
   id,
 }: TranslateMessageParams): string => {
@@ -283,12 +285,24 @@ const keepTheBlanks = (
   )
 }
 
+export const appendInvisibleCharacter = (text: string) =>
+  text + INVISIBLE_CHARACTER
+
+const removeInvisibleCharacter = (text: string) => {
+  const lastIndex = text.length - 1
+
+  if (text[lastIndex] !== INVISIBLE_CHARACTER) {
+    return text
+  }
+
+  return text.slice(0, lastIndex)
+}
+
 export const getImplementation = (component: string) => {
   return global.__RENDER_8_COMPONENTS__[component]
 }
 
 export const getSchemaPropsOrContent = ({
-  i18nMapping,
   messages,
   schema,
   propsOrContent,
@@ -306,18 +320,21 @@ export const getSchemaPropsOrContent = ({
         return acc
       }
 
-      if (IO_MESSAGE_FORMATS.includes(format) && messages) {
-        const id =
-          i18nMapping && i18nMapping[value] !== undefined
-            ? i18nMapping[value]
-            : value
+      if (IO_MESSAGE_FORMATS.includes(format)) {
+        let adaptedValue
 
-        const ioMessage = translateMessage({
-          dictionary: messages,
-          id,
-        })
+        if (messages) {
+          adaptedValue = translateMessage({
+            dictionary: messages,
+            id: value,
+          })
+        } else {
+          // Removes the invisible character from i18n fields. For more
+          // information, please check the I18nInput widget.
+          adaptedValue = removeInvisibleCharacter(value)
+        }
 
-        return { ...acc, ...assocPath(dataPath, ioMessage, acc) }
+        return { ...acc, ...assocPath(dataPath, adaptedValue, acc) }
       }
 
       return { ...acc, ...assocPath(dataPath, value, acc) }

--- a/react/utils/components/typings.d.ts
+++ b/react/utils/components/typings.d.ts
@@ -1,8 +1,6 @@
 import { JSONSchema6 } from 'json-schema'
 import { RenderComponent } from 'vtex.render-runtime'
 
-import { FormMetaContext } from '../../components/EditorContainer/Sidebar/typings'
-
 export type PropsOrContent = Extension['content'] | Extension['props']
 
 export interface GetComponentSchemaParams {
@@ -14,8 +12,6 @@ export interface GetComponentSchemaParams {
 }
 
 export interface GetSchemaPropsOrContentParams {
-  i18nMapping?: FormMetaContext['i18nMapping']
-  isContent?: boolean
   messages?: RenderContext['messages']
   schema?: JSONSchema6Definition
   propsOrContent?: Record<string, unknown>

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1484,11 +1484,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-any-base@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
-  integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
-
 any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
@@ -7028,14 +7023,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-short-uuid@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/short-uuid/-/short-uuid-3.1.1.tgz#3ff427074b5fa7822c3793994d18a7a82e2f73a4"
-  integrity sha512-7dI69xtJYpTIbg44R6JSgrbDtZFuZ9vAwwmnF/L0PinykbFrhQ7V8omKsQcVw1TP0nYJ7uQp1PN6/aVMkzQFGQ==
-  dependencies:
-    any-base "^1.1.0"
-    uuid "^3.3.2"
 
 shortid@^2.2.14:
   version "2.2.14"


### PR DESCRIPTION
#### What problem is this solving?

When editing i18n fields, there are a few scenarios in which the i18n key itself is being saved/displayed; this PR addresses that issue.

#### How should this be manually tested?

[Workspace](https://fixi18nsaving--alssports.myvtex.com/admin/app/cms/site-editor/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Edit any block with i18n fields, e.g. "Rich Text".

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| ✔️  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

While there isn't currently an efficient way to update the inner Runtime's intl, this solution uses the `IOMessage`'s fallback behavior to modify i18n properties. Since the value actually represents an i18n key, typing in the name of an existing one would cause the block to render the corresponding intl string. In order to prevent that, `I18nInput` now adds an invisible character after the input value, so it will (probably) never match an i18n key. The invisible character is removed once the form is submitted, before being sent to the server.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/YQitE4YNQNahy/giphy-downsized.gif)
