### PR TITLE
Domain messages local cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Local cache to function `editorMessagesFromRuntime`.
+- Localization to confirm prompt when attempting to navigate with open form.
+
 ## [4.12.4] - 2019-09-18
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -160,6 +160,7 @@
   "admin/pages.editor.container.dev-mode-warning.text": "admin/pages.editor.container.dev-mode-warning.text",
   "admin/pages.editor.container.editpath.label": "admin/pages.editor.container.editpath.label",
   "admin/pages.editor.container.master-workspace-warning.text": "admin/pages.editor.container.master-workspace-warning.text",
+  "admin/pages.editor.iframe.confirm-prompt": "admin/pages.editor.iframe.confirm-prompt",
   "admin/pages.editor.image-uploader.empty.button": "admin/pages.editor.image-uploader.empty.button",
   "admin/pages.editor.image-uploader.empty.subtext-1": "admin/pages.editor.image-uploader.empty.subtext-1",
   "admin/pages.editor.image-uploader.empty.subtext-2": "admin/pages.editor.image-uploader.empty.subtext-2",
@@ -262,7 +263,7 @@
   "admin/pages.admin.rich-text-editor.ordered-list.title": "admin/pages.admin.rich-text-editor.ordered-list.title",
   "admin/pages.admin.rich-text-editor.unordered-list.title": "admin/pages.admin.rich-text-editor.unordered-list.title",
   "admin/pages.admin.rich-text-editor.link.title": "admin/pages.admin.rich-text-editor.link.title",
-  
+
   "admin/pages.admin.content.general.section-title": "admin/pages.admin.content.general.section-title",
   "admin/pages.admin.content.general.title.label": "admin/pages.admin.content.general.title.label",
   "admin/pages.admin.content.general.title.placeholder": "admin/pages.admin.content.general.title.placeholder",

--- a/messages/context.json
+++ b/messages/context.json
@@ -263,7 +263,6 @@
   "admin/pages.admin.rich-text-editor.ordered-list.title": "admin/pages.admin.rich-text-editor.ordered-list.title",
   "admin/pages.admin.rich-text-editor.unordered-list.title": "admin/pages.admin.rich-text-editor.unordered-list.title",
   "admin/pages.admin.rich-text-editor.link.title": "admin/pages.admin.rich-text-editor.link.title",
-
   "admin/pages.admin.content.general.section-title": "admin/pages.admin.content.general.section-title",
   "admin/pages.admin.content.general.title.label": "admin/pages.admin.content.general.title.label",
   "admin/pages.admin.content.general.title.placeholder": "admin/pages.admin.content.general.title.placeholder",

--- a/messages/en.json
+++ b/messages/en.json
@@ -160,6 +160,7 @@
   "admin/pages.editor.container.dev-mode-warning.text": "You are in development mode. Changes to the content will not go to production.",
   "admin/pages.editor.container.editpath.label": "Page URL:",
   "admin/pages.editor.container.master-workspace-warning.text": "You are editing the live store. Changes will have immediate effect.",
+  "admin/pages.editor.iframe.confirm-prompt": "Are you sure you want to leave?",
   "admin/pages.editor.image-uploader.empty.button": "Upload",
   "admin/pages.editor.image-uploader.empty.subtext-1": "or",
   "admin/pages.editor.image-uploader.empty.subtext-2": "drag and drop",

--- a/messages/es.json
+++ b/messages/es.json
@@ -160,6 +160,7 @@
   "admin/pages.editor.container.dev-mode-warning.text": "Usted está en el modo de desarrollo. Los cambios en el contenido no podrán ir a la tienda en producción.",
   "admin/pages.editor.container.editpath.label": "URL de la página:",
   "admin/pages.editor.container.master-workspace-warning.text": "Usted está editando la tienda en producción. Los cambios en el contenido tendrán un efecto inmediato.",
+  "admin/pages.editor.iframe.confirm-prompt": "Estás seguro que quieres irte?",
   "admin/pages.editor.image-uploader.empty.button": "Hacer upload",
   "admin/pages.editor.image-uploader.empty.subtext-1": "o",
   "admin/pages.editor.image-uploader.empty.subtext-2": "arrastrar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -160,6 +160,7 @@
   "admin/pages.editor.container.dev-mode-warning.text": "Você está em modo de desenvolvimento. Mudanças no conteúdo não poderão ir pra loja em produção.",
   "admin/pages.editor.container.editpath.label": "URL da página:",
   "admin/pages.editor.container.master-workspace-warning.text": "Você está editando a loja em produção. Mudanças no conteúdo terão um efeito imediato.",
+  "admin/pages.editor.iframe.confirm-prompt": "Tem certeza que deseja sair?",
   "admin/pages.editor.image-uploader.empty.button": "Fazer upload",
   "admin/pages.editor.image-uploader.empty.subtext-1": "ou",
   "admin/pages.editor.image-uploader.empty.subtext-2": "arraste",

--- a/react/components/DomainMessages/editorMessagesFromRuntime.ts
+++ b/react/components/DomainMessages/editorMessagesFromRuntime.ts
@@ -31,22 +31,24 @@ export const editorMessagesFromRuntime = async ({
 }: Props) => {
   const { components, renderMajor } = runtime
   const allComponentNames = keys(components)
-  const componentNames = new Set<string>()
 
-  allComponentNames.forEach(componentName => {
-    if (!fetchedKeys.has(componentName)) {
-      componentNames.add(componentName)
+  const componentNamesToFetch = allComponentNames.filter(componentName => {
+    const shouldFetchComponent = !fetchedKeys.has(componentName)
+
+    if (shouldFetchComponent) {
       fetchedKeys.add(componentName)
     }
+
+    return shouldFetchComponent
   })
 
-  if (componentNames.size === 0) {
+  if (componentNamesToFetch.length === 0) {
     return cachedResult
   }
 
   const componentsBatch = splitEvery(
     MAX_COMPONENTES_PER_QUERY,
-    Array.from<string>(componentNames)
+    componentNamesToFetch
   )
 
   const responses = map(

--- a/react/components/DomainMessages/editorMessagesFromRuntime.ts
+++ b/react/components/DomainMessages/editorMessagesFromRuntime.ts
@@ -1,0 +1,80 @@
+import { keys, map, splitEvery } from 'ramda'
+
+import { Data, Message, Props, Variables } from './typings'
+
+import messagesForDomainQuery from '../../queries/MessagesForDomain.graphql'
+
+const MAX_COMPONENTES_PER_QUERY = 100
+
+const messagesToReactIntlFormat = (messages: Message[]) =>
+  messages.reduce((acc, { key, message }) => ({ ...acc, [key]: message }), {})
+
+const reduceP = async <T, K>(
+  fn: (acc: K, item: T) => Promise<K>,
+  intialValue: K,
+  list: T[]
+) => {
+  let acc = intialValue
+  for (const item of list) {
+    acc = await fn(acc, item)
+  }
+  return acc
+}
+
+let cachedResult: Record<string, string> = {}
+const fetchedKeys = new Set()
+
+export const editorMessagesFromRuntime = async ({
+  client,
+  domain,
+  runtime,
+}: Props) => {
+  const { components, renderMajor } = runtime
+  const allComponentNames = keys(components)
+  const componentNames = new Set<string>()
+
+  allComponentNames.forEach(componentName => {
+    if (!fetchedKeys.has(componentName)) {
+      componentNames.add(componentName)
+      fetchedKeys.add(componentName)
+    }
+  })
+
+  if (componentNames.size === 0) {
+    return cachedResult
+  }
+
+  const componentsBatch = splitEvery(
+    MAX_COMPONENTES_PER_QUERY,
+    Array.from<string>(componentNames)
+  )
+
+  const responses = map(
+    batch =>
+      client.query<Data, Variables>({
+        fetchPolicy: 'network-only',
+        query: messagesForDomainQuery,
+        variables: {
+          components: batch,
+          domain,
+          renderMajor,
+        },
+      }),
+    componentsBatch
+  )
+  const messages = await reduceP(
+    async (acc, response) => {
+      const {
+        data: { messages: batchMessages },
+      } = await response
+      return [...acc, ...batchMessages]
+    },
+    [] as Message[],
+    responses
+  )
+
+  const messagesInReactIntlFormat = messagesToReactIntlFormat(messages)
+  cachedResult = { ...cachedResult, ...messagesInReactIntlFormat }
+
+  return messagesInReactIntlFormat
+}

--- a/react/components/DomainMessages/editorMessagesFromRuntime.ts
+++ b/react/components/DomainMessages/editorMessagesFromRuntime.ts
@@ -4,7 +4,7 @@ import { Data, Message, Props, Variables } from './typings'
 
 import messagesForDomainQuery from '../../queries/MessagesForDomain.graphql'
 
-const MAX_COMPONENTES_PER_QUERY = 100
+const MAX_COMPONENTS_PER_QUERY = 100
 
 const messagesToReactIntlFormat = (messages: Message[]) =>
   messages.reduce((acc, { key, message }) => ({ ...acc, [key]: message }), {})
@@ -47,7 +47,7 @@ export const editorMessagesFromRuntime = async ({
   }
 
   const componentsBatch = splitEvery(
-    MAX_COMPONENTES_PER_QUERY,
+    MAX_COMPONENTS_PER_QUERY,
     componentNamesToFetch
   )
 

--- a/react/components/DomainMessages/index.tsx
+++ b/react/components/DomainMessages/index.tsx
@@ -1,126 +1,16 @@
 // This file is .tsx because otherwise the babel plugin for messages doesn't work.
-import ApolloClient from 'apollo-client'
-import { concat, keys, map, splitEvery } from 'ramda'
-
-import { InjectedIntl } from 'react-intl'
+import { concat } from 'ramda'
 import languagesQuery from '../../queries/Languages.graphql'
-import messagesForDomainQuery from '../../queries/MessagesForDomain.graphql'
 import messages from './cultureMessages'
+import {
+  AvailableCulturesProps,
+  LabelledLocale,
+  Languages,
+  Variables,
+} from './typings'
 
-const MAX_COMPONENTES_PER_QUERY = 100
 // TODO: Remove this when messages solve this case
 const DEFAULT_LANGUAGES = ['en-US', 'pt-BR', 'es-AR']
-
-interface Props {
-  runtime: RenderContext
-  domain: string
-  client: ApolloClient<unknown>
-}
-
-interface AvailableCulturesProps {
-  client: ApolloClient<unknown>
-  intl: InjectedIntl
-}
-
-interface Message {
-  key: string
-  message: string
-}
-
-interface Data {
-  messages: Message[]
-}
-
-interface Variables {
-  components: string[]
-  domain: string
-  renderMajor: number
-}
-
-interface Languages {
-  languages: {
-    default: string
-    supported: string[]
-  }
-}
-
-export interface LabelledLocale {
-  label: string
-  value: string
-}
-
-const messagesToReactIntlFormat = (messages: Message[]) =>
-  messages.reduce((acc, { key, message }) => ({ ...acc, [key]: message }), {})
-
-const reduceP = async <T, K>(
-  fn: (acc: K, item: T) => Promise<K>,
-  intialValue: K,
-  list: T[]
-) => {
-  let acc = intialValue
-  for (const item of list) {
-    acc = await fn(acc, item)
-  }
-  return acc
-}
-
-let cachedResult: Record<string, string> = {}
-const fetchedKeys = new Set()
-
-export const editorMessagesFromRuntime = async ({
-  client,
-  domain,
-  runtime,
-}: Props) => {
-  const { components, renderMajor } = runtime
-  const allComponentNames = keys(components)
-  const componentNames = new Set<string>()
-
-  allComponentNames.forEach(componentName => {
-    if (!fetchedKeys.has(componentName)) {
-      componentNames.add(componentName)
-      fetchedKeys.add(componentName)
-    }
-  })
-
-  if (componentNames.size === 0) {
-    return cachedResult
-  }
-
-  const componentsBatch = splitEvery(
-    MAX_COMPONENTES_PER_QUERY,
-    Array.from<string>(componentNames)
-  )
-
-  const responses = map(
-    batch =>
-      client.query<Data, Variables>({
-        fetchPolicy: 'network-only',
-        query: messagesForDomainQuery,
-        variables: {
-          components: batch,
-          domain,
-          renderMajor,
-        },
-      }),
-    componentsBatch
-  )
-  const messages = await reduceP(
-    async (acc, response) => {
-      const {
-        data: { messages: batchMessages },
-      } = await response
-      return [...acc, ...batchMessages]
-    },
-    [] as Message[],
-    responses
-  )
-
-  const messagesInReactIntlFormat = messagesToReactIntlFormat(messages)
-  cachedResult = { ...cachedResult, ...messagesInReactIntlFormat }
-
-  return messagesInReactIntlFormat
-}
 
 function isValidLang(key: string): key is keyof typeof messages {
   return Object.prototype.hasOwnProperty.call(messages, key)
@@ -164,3 +54,6 @@ export const getAvailableCultures = async ({
       a.label.localeCompare(b.label)
     )
 }
+
+export { LabelledLocale }
+export { editorMessagesFromRuntime } from './editorMessagesFromRuntime'

--- a/react/components/DomainMessages/typings.d.ts
+++ b/react/components/DomainMessages/typings.d.ts
@@ -1,0 +1,40 @@
+import ApolloClient from 'apollo-client'
+import { InjectedIntl } from 'react-intl'
+
+export interface Props {
+  runtime: RenderContext
+  domain: string
+  client: ApolloClient<unknown>
+}
+
+export interface Message {
+  key: string
+  message: string
+}
+
+export interface Data {
+  messages: Message[]
+}
+
+export interface Variables {
+  components: string[]
+  domain: string
+  renderMajor: number
+}
+
+export interface AvailableCulturesProps {
+  client: ApolloClient<unknown>
+  intl: InjectedIntl
+}
+
+export interface Languages {
+  languages: {
+    default: string
+    supported: string[]
+  }
+}
+
+export interface LabelledLocale {
+  label: string
+  value: string
+}

--- a/react/components/EditorContainer/IframeNavigationController.tsx
+++ b/react/components/EditorContainer/IframeNavigationController.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react'
-import { useRuntime } from 'vtex.render-runtime'
+import { defineMessages, injectIntl, InjectedIntlProps } from 'react-intl'
 import { useEditorContext } from '../EditorContext'
 import { useFormMetaContext } from './Sidebar/FormMetaContext'
 
-interface Props {
+interface Props extends InjectedIntlProps {
   iframeRuntime: RenderContext | null
 }
 
@@ -13,21 +13,17 @@ const maybeCall = (fn: (() => void) | void) => {
   }
 }
 
-function getConfirmationMessage(language: string) {
-  const messages: Record<string, string> = {
-    en: 'Are you sure you want to leave?',
-    es: 'Estás seguro que quieres irte?',
-    pt: 'Tem certeza que deseja sair?',
-  }
-  return messages[language] || messages.en
-}
+const messages = defineMessages({
+  confirm: {
+    defaultMessage: 'Are you sure you want to leave?',
+    id: 'admin/pages.editor.iframe.confirm-prompt',
+  },
+})
 
 const IframeNavigationController: React.FunctionComponent<Props> = ({
   iframeRuntime,
+  intl,
 }) => {
-  const {
-    culture: { language },
-  } = useRuntime()
   const { getWasModified, setWasModified } = useFormMetaContext()
   const { editExtensionPoint } = useEditorContext()
 
@@ -38,7 +34,9 @@ const IframeNavigationController: React.FunctionComponent<Props> = ({
     let unlisten: (() => void) | void
 
     if (wasModified && iframeRuntime && iframeRuntime.history) {
-      unblock = iframeRuntime.history.block(getConfirmationMessage(language))
+      unblock = iframeRuntime.history.block(
+        intl.formatMessage(messages.confirm)
+      )
       unlisten = iframeRuntime.history.listen((_, action) => {
         const hasNavigated = ['PUSH', 'REPLACE', 'POP'].includes(action)
         if (hasNavigated) {
@@ -54,9 +52,9 @@ const IframeNavigationController: React.FunctionComponent<Props> = ({
       unblock = maybeCall(unblock)
       unlisten = maybeCall(unlisten)
     }
-  }, [editExtensionPoint, iframeRuntime, language, setWasModified, wasModified])
+  }, [editExtensionPoint, iframeRuntime, setWasModified, wasModified, intl])
 
   return null
 }
 
-export default IframeNavigationController
+export default injectIntl(IframeNavigationController)

--- a/react/components/EditorContainer/IframeNavigationController.tsx
+++ b/react/components/EditorContainer/IframeNavigationController.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
 import { useEditorContext } from '../EditorContext'
 import { useFormMetaContext } from './Sidebar/FormMetaContext'
 
@@ -12,9 +13,21 @@ const maybeCall = (fn: (() => void) | void) => {
   }
 }
 
+function getConfirmationMessage(language: string) {
+  const messages: Record<string, string> = {
+    en: 'Are you sure you want to leave?',
+    es: 'Estás seguro que quieres irte?',
+    pt: 'Tem certeza que deseja sair?',
+  }
+  return messages[language] || messages.en
+}
+
 const IframeNavigationController: React.FunctionComponent<Props> = ({
   iframeRuntime,
 }) => {
+  const {
+    culture: { language },
+  } = useRuntime()
   const { getWasModified, setWasModified } = useFormMetaContext()
   const { editExtensionPoint } = useEditorContext()
 
@@ -25,7 +38,7 @@ const IframeNavigationController: React.FunctionComponent<Props> = ({
     let unlisten: (() => void) | void
 
     if (wasModified && iframeRuntime && iframeRuntime.history) {
-      unblock = iframeRuntime.history.block('Are you sure you want to leave?')
+      unblock = iframeRuntime.history.block(getConfirmationMessage(language))
       unlisten = iframeRuntime.history.listen((_, action) => {
         const hasNavigated = ['PUSH', 'REPLACE', 'POP'].includes(action)
         if (hasNavigated) {
@@ -41,9 +54,9 @@ const IframeNavigationController: React.FunctionComponent<Props> = ({
       unblock = maybeCall(unblock)
       unlisten = maybeCall(unlisten)
     }
-  }, [editExtensionPoint, iframeRuntime, setWasModified, wasModified])
+  }, [editExtensionPoint, iframeRuntime, language, setWasModified, wasModified])
 
-  return <></>
+  return null
 }
 
 export default IframeNavigationController

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -106,6 +106,7 @@ class EditorProvider extends Component<Props, State> {
         }
 
         const newMessages = {
+          ...this.state.messages,
           ...messages,
           ...formattedEditorMessages,
         }


### PR DESCRIPTION
#### What problem is this solving?

Every time there's a change, the `__provideRuntime` function calls the `messages` service, even when there are no changes in the components. This is extremely inefficient since the request takes ~2s on a fast internet and on the smallest store (`storecomponents`).

So to improve the responsiveness, this PR adds a local cache that returns the messages and avoids making the request if possible.

**Bonus change:** Add localized messages for confirm prompt that opens when you try to navigate while form is open.

#### How should this be manually tested?

[Workspace](https://messageslocalcache--storecomponents.myvtex.com/admin/cms/site-editor/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Doing:
1. Open configuration
2. Type something and wait for change on iframe
3. Type something and wait for change on iframe

Before:
<img width="407" alt="Screen Shot 2019-09-17 at 15 08 40" src="https://user-images.githubusercontent.com/10400340/65068681-72a44700-d95f-11e9-9b33-cafd8a9c7ef9.png">

After:
<img width="407" alt="Screen Shot 2019-09-17 at 15 05 59" src="https://user-images.githubusercontent.com/10400340/65068698-789a2800-d95f-11e9-9548-e1952c00ccb1.png">


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3otPoo8NDLOmzvTJF6/giphy.gif)
