### PR TITLE
Fix widgets' onChange and recent i18n changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Widgets' `onChange` and, consequently, v4.12.3's i18n solution.
+
 ## [4.12.3] - 2019-09-17
 
 ### Changed

--- a/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
+++ b/react/components/EditorContainer/Sidebar/ConfigurationList/index.tsx
@@ -522,9 +522,9 @@ class ConfigurationList extends React.Component<Props, State> {
     }
   }
 
-  private handleFormChange: FormProps<{
-    formData: object
-  }>['onChange'] = event => {
+  private handleFormChange: FormProps<
+    FormDataContainer
+  >['onChange'] = event => {
     const { editor, formMeta, iframeRuntime } = this.props
 
     if (

--- a/react/components/form/BaseInput.tsx
+++ b/react/components/form/BaseInput.tsx
@@ -5,7 +5,8 @@ import { Input } from 'vtex.styleguide'
 
 import { CustomWidgetProps } from './typings'
 
-interface Props extends CustomWidgetProps<HTMLInputElement>, InjectedIntlProps {
+interface Props extends CustomWidgetProps, InjectedIntlProps {
+  isI18n?: boolean
   label: string
   max?: number
   min?: number
@@ -21,10 +22,12 @@ const BaseInput: React.FunctionComponent<Props> = props => {
     disabled,
     id,
     intl,
+    isI18n,
     label,
     max,
     min,
     onBlur,
+    onChange,
     onFocus,
     options,
     placeholder,
@@ -41,9 +44,16 @@ const BaseInput: React.FunctionComponent<Props> = props => {
 
   const currentError = rawErrors && rawErrors[0]
 
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
-    props.onChange(event.target.value || '', event.target)
-
+  const handleChange = React.useCallback(
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      if (isI18n) {
+        onChange({ target, value: target.value || '' })
+      } else {
+        onChange(target.value)
+      }
+    },
+    [isI18n, onChange]
+  )
   return (
     <Input
       disabled={disabled || schema.disabled}
@@ -62,7 +72,7 @@ const BaseInput: React.FunctionComponent<Props> = props => {
         ((event: React.ChangeEvent<HTMLInputElement>) =>
           onBlur(id, event.target.value))
       }
-      onChange={onChange}
+      onChange={handleChange}
       onFocus={
         onFocus &&
         ((event: React.ChangeEvent<HTMLInputElement>) =>

--- a/react/components/form/I18nInput/index.tsx
+++ b/react/components/form/I18nInput/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
-import { appendInvisibleCharacter } from '../../utils/components'
+import { appendInvisibleCharacter } from '../../../utils/components'
+import BaseInput from '../BaseInput'
+import TextArea from '../TextArea'
+import { CustomWidgetProps } from '../typings'
 
-import BaseInput from './BaseInput'
-import TextArea from './TextArea'
-import { CustomWidgetProps } from './typings'
+import { isValidData } from './utils'
 
 interface Props extends CustomWidgetProps {
   isTextarea?: boolean
@@ -32,13 +33,13 @@ const I18nInput: React.FunctionComponent<Props> = ({
 }) => {
   const [localValue, setLocalValue] = React.useState(value)
 
-  const safeOnChange: CustomWidgetProps<
-    HTMLInputElement | HTMLTextAreaElement
-  >['onChange'] = React.useCallback(
-    (newValue, target) => {
-      if (typeof newValue !== 'string' || !target) {
+  const safeOnChange: CustomWidgetProps['onChange'] = React.useCallback(
+    data => {
+      if (!isValidData(data)) {
         return
       }
+
+      const { target, value: newValue } = data
 
       let cursorPosition = target.selectionStart
 
@@ -56,6 +57,7 @@ const I18nInput: React.FunctionComponent<Props> = ({
 
   const finalProps = {
     ...commonProps,
+    isI18n: true,
     onChange: safeOnChange,
     value: localValue,
   }

--- a/react/components/form/I18nInput/utils.ts
+++ b/react/components/form/I18nInput/utils.ts
@@ -1,0 +1,10 @@
+export const isValidData = (
+  data: unknown
+): data is {
+  target: HTMLInputElement | HTMLTextAreaElement
+  value: string
+} =>
+  typeof data === 'object' &&
+  data !== null &&
+  Object.prototype.hasOwnProperty.call(data, 'target') &&
+  Object.prototype.hasOwnProperty.call(data, 'value')

--- a/react/components/form/TextArea.tsx
+++ b/react/components/form/TextArea.tsx
@@ -5,12 +5,15 @@ import { Textarea } from 'vtex.styleguide'
 
 import { CustomWidgetProps } from './typings'
 
-type Props = CustomWidgetProps<HTMLTextAreaElement> & InjectedIntlProps
+interface Props extends CustomWidgetProps, InjectedIntlProps {
+  isI18n?: boolean
+}
 
 const TextArea: React.FunctionComponent<Props> = ({
   disabled,
   id,
   intl,
+  isI18n,
   label,
   onBlur,
   onChange,
@@ -31,10 +34,14 @@ const TextArea: React.FunctionComponent<Props> = ({
   )
 
   const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(event.target.value || '', event.target)
+    ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (isI18n) {
+        onChange({ target, value: target.value || '' })
+      } else {
+        onChange(target.value)
+      }
     },
-    [onChange]
+    [isI18n, onChange]
   )
 
   const handleFocus = React.useCallback(

--- a/react/components/form/typings.d.ts
+++ b/react/components/form/typings.d.ts
@@ -1,11 +1,11 @@
 import { WidgetProps } from 'react-jsonschema-form'
 
-export interface CustomWidgetProps<T = unknown> extends WidgetProps {
+export interface CustomWidgetProps extends WidgetProps {
   formContext: {
     messages: RenderContext['messages']
     isLayout: boolean
   }
-  onChange: (value: unknown, target?: React.ChangeEvent<T>['target']) => void
+  onChange: (value: unknown) => void
   rawErrors?: string[]
   schema: WidgetProps['schema'] & {
     disabled?: boolean


### PR DESCRIPTION
#### What problem is this solving?

The PR #279 used the second argument of the `onChange` function to pass the event target to `I18nInput`, but it turns out that RJSF's default `onChange` handles its second argument in a different way, so non-i18n text inputs ended up throwing some errors; this PR addresses that issue.

#### How should this be manually tested?

[Workspace 1](https://fixi18nsaving--alssports.myvtex.com/admin/app/cms/site-editor/)
[Workspace 2](https://fixi18nsaving--exitocol.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Edit any text input field.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

N/A.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/YUG7qlbCeRutqL1jPU/giphy.gif)
