### PR TITLE
Add checkout option in promptOnCustomEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add `On the first purchase` prompt event option in `PWAForm`. 
 
 ## [4.14.3] - 2019-10-28
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -425,6 +425,7 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "admin/pages.editor.store.settings.pwa.orientation.portrait",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart": "admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart",
+  "admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout": "admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.default": "admin/pages.editor.store.settings.pwa.prompt-custom-event.default",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event": "admin/pages.editor.store.settings.pwa.prompt-custom-event",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "admin/pages.editor.store.settings.pwa.screen-orientation",

--- a/messages/en.json
+++ b/messages/en.json
@@ -425,6 +425,7 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Portrait (Secondary)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Portrait",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart": "On the first item added to cart",
+  "admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout": "On the first purchase",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.default": "On the first visit",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event": "Prompt \"Add to Home Screen\"",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Screen Orientation",

--- a/messages/es.json
+++ b/messages/es.json
@@ -425,6 +425,7 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Retrato (Secundario)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Retrato",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart": "En el primer artículo agregado al carrito",
+  "admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout": "En la primera compra",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.default": "En la primera visita",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event": "Prompt \"Add to Home Screen\"",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Orientación de la pantalla",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -425,6 +425,7 @@
   "admin/pages.editor.store.settings.pwa.orientation.portrait-secondary": "Retrato (Secundário)",
   "admin/pages.editor.store.settings.pwa.orientation.portrait": "Retrato",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart": "No primeiro item adicionado ao carrinho",
+  "admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout": "Na primeira compra",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event.default": "Na primeira visita",
   "admin/pages.editor.store.settings.pwa.prompt-custom-event": "Prompt \"Add to Home Screen\"",
   "admin/pages.editor.store.settings.pwa.screen-orientation": "Orientação da Tela",

--- a/react/components/EditorContainer/StoreEditor/Store/PWAForm/utils/constants.ts
+++ b/react/components/EditorContainer/StoreEditor/Store/PWAForm/utils/constants.ts
@@ -70,6 +70,10 @@ export const INSTALL_PROMPT_OPTIONS: DropdownOption[] = [
     label: 'admin/pages.editor.store.settings.pwa.prompt-custom-event.addToCart',
     value: 'addToCart',
   },
+  {
+    label: 'admin/pages.editor.store.settings.pwa.prompt-custom-event.checkout',
+    value: 'checkout',
+  }
 ]
 
 export const TOAST_DURATION = 4000


### PR DESCRIPTION
#### What problem is this solving?
Now it's possible to show ` 'add to home screen'` prompt from order placed.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thay--storecomponents.myvtex.com/checkout/orderPlaced/?og=949500478939)
<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
|  ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |
