### PR TITLE
Fix page form schema's default template selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Page form schema's default template selection.
+
 ## [2.7.2] - 2019-09-06
 
 ## [4.10.4] - 2019-09-03

--- a/react/components/PageForm.tsx
+++ b/react/components/PageForm.tsx
@@ -18,6 +18,10 @@ import ObjectFieldTemplate from './form/ObjectFieldTemplate'
 import Radio from './form/Radio'
 import Toggle from './form/Toggle'
 
+interface Props extends Record<string, any> {
+  templates: Template[]
+}
+
 const defaultUiSchema = {
   classNames: 'pages-editor-form',
   conditions: {
@@ -102,7 +106,7 @@ const CUSTOM_ROUTE = [
   },
 ]
 
-class PageForm extends Component<any, any> {
+class PageForm extends Component<Props, any> {
   public static propTypes = {
     availableConditions: PropTypes.arrayOf(PropTypes.string).isRequired,
     configurationId: PropTypes.string,
@@ -121,7 +125,7 @@ class PageForm extends Component<any, any> {
     value: r.id,
   }))
 
-  constructor(props: any) {
+  constructor(props: Props) {
     super(props)
 
     let page: any
@@ -137,6 +141,14 @@ class PageForm extends Component<any, any> {
       }
     })
 
+    const templateObj =
+      page &&
+      props.templates.find(
+        template =>
+          template.id.replace(/(@\d+\.)\d+\.\d+(\/)/, '$1x$2') ===
+          page.template,
+      )
+
     this.state = {
       allMatches: page && page.allMatches,
       availableConditions: props.availableConditions,
@@ -151,7 +163,7 @@ class PageForm extends Component<any, any> {
       routeDeclarer: route && route.declarer,
       routeId: route && route.id,
       selectedRouteId: route && route.id,
-      template: page && page.template,
+      template: templateObj && templateObj.id,
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

When editing an existing page, the available templates' IDs hold the complete version of the origin app, while the page's template uses the `<major>.x` format. Therefore, the active template will never match any of the available ones; this PR addresses that issue.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://phdro--madesa.myvtex.com/admin/cms/pages)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Open existing pages and make sure that the corresponding template appears as the default value for the selector.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

N/A.

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

<img width="300" src="https://media.giphy.com/media/l4pT8p6AkNEorZvSE/giphy.gif" />
