### PR TITLE
Add error handling to ListContent query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug in which the content would load forever.
+
 ## [4.13.0] - 2019-10-18
 
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -145,6 +145,7 @@
   "admin/pages.editor.components.modal.button.discard": "admin/pages.editor.components.modal.button.discard",
   "admin/pages.editor.components.modal.text": "admin/pages.editor.components.modal.text",
   "admin/pages.editor.components.no-image": "admin/pages.editor.components.no-image",
+  "admin/pages.editor.components.open.error": "admin/pages.editor.components.open.error",
   "admin/pages.editor.components.title": "admin/pages.editor.components.title",
   "admin/pages.editor.configuration.button.create": "admin/pages.editor.configuration.button.create",
   "admin/pages.editor.configuration.condition.date.from": "admin/pages.editor.configuration.condition.date.from",

--- a/messages/en.json
+++ b/messages/en.json
@@ -145,6 +145,7 @@
   "admin/pages.editor.components.modal.button.discard": "Discard",
   "admin/pages.editor.components.modal.text": "You have unsaved modifications.",
   "admin/pages.editor.components.no-image": "No image",
+  "admin/pages.editor.components.open.error": "Something went wrong. Please try again.",
   "admin/pages.editor.components.title": "Blocks",
   "admin/pages.editor.configuration.button.create": "New content",
   "admin/pages.editor.configuration.condition.date.from": "Start:",

--- a/messages/es.json
+++ b/messages/es.json
@@ -145,6 +145,7 @@
   "admin/pages.editor.components.modal.button.discard": "Descartar",
   "admin/pages.editor.components.modal.text": "Tiene modificaciones no guardadas.",
   "admin/pages.editor.components.no-image": "Sin imágen",
+  "admin/pages.editor.components.open.error": "Algo salió mal. Por favor, inténtalo de nuevo.",
   "admin/pages.editor.components.title": "Bloques",
   "admin/pages.editor.configuration.button.create": "Nuevo contenido",
   "admin/pages.editor.configuration.condition.date.from": "Inicio:",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -145,6 +145,7 @@
   "admin/pages.editor.components.modal.button.discard": "Descartar",
   "admin/pages.editor.components.modal.text": "Você tem modificações não salvas.",
   "admin/pages.editor.components.no-image": "Sem imagem",
+  "admin/pages.editor.components.open.error": "Algo deu errado. Por favor, tente novamente.",
   "admin/pages.editor.components.title": "Blocos",
   "admin/pages.editor.configuration.button.create": "Novo conteúdo",
   "admin/pages.editor.configuration.condition.date.from": "Início:",


### PR DESCRIPTION
#### What problem is this solving?

Eternal loading when the ListContent query fails.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Both of the workspace below contain the new code, but there's an error being thrown on purpose in the first one.

To check the error handling: [workspace](https://fixcontenteternalloadingwitherror--storecomponents.myvtex.com/admin/app/cms/site-editor).

To make sure everything else still works: [workspace](https://fixcontenteternalloading--storecomponents.myvtex.com/admin/app/cms/site-editor).

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

N/A.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

N/A.

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

<img width="250" src="https://media.giphy.com/media/13Qumr2SLqrl5e/giphy.gif" />
