### PR TITLE
Fix highlight bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Highlighting last valid block when clicking to edit a block that isn't rendered or isn't valid, i.e., isn't editable.
+- Highlighting block that isn't visible on the screen due to `overflow: hidden` (e.g., `Product Summary` on `Shelf`): Try to get the block closer to the middle of the window when selecting from a list of blocks (e.g.)
+
 ## [4.13.1] - 2019-10-18
 
 ### Fixed

--- a/react/components/HighlightOverlay/hooks/useHighlightedElementInfo.ts
+++ b/react/components/HighlightOverlay/hooks/useHighlightedElementInfo.ts
@@ -22,15 +22,43 @@ function getElementInfo(
 
   const elementsArray: Element[] = Array.prototype.slice.call(elements)
 
-  const visibleElement = elementsArray.find(currElement => {
-    const currRect = currElement.getBoundingClientRect()
+  const viewportMiddle =
+    (window.innerWidth || document.documentElement.clientWidth) / 2
 
-    return (
-      currRect.width > 0 &&
-      currRect.height > 0 &&
-      isElementInHorizontalAxis(currElement)
-    )
-  })
+  const visibleElementsClosestToMiddle = elementsArray
+    .filter(currElement => {
+      const currRect = currElement.getBoundingClientRect()
+
+      return (
+        currRect.width > 0 &&
+        currRect.height > 0 &&
+        isElementInHorizontalAxis(currElement)
+      )
+    })
+    .sort((elemA, elemB) => {
+      const rectA = elemA.getBoundingClientRect()
+      const rectB = elemB.getBoundingClientRect()
+      const middleA = rectA.left || 0 + rectA.width
+      const middleB = rectB.left || 0 + rectB.width
+
+      const differenceA =
+        viewportMiddle - middleA < 0
+          ? middleA - viewportMiddle
+          : viewportMiddle - middleA
+      const differenceB =
+        viewportMiddle - middleB < 0
+          ? middleB - viewportMiddle
+          : viewportMiddle - middleB
+
+      if (differenceA < differenceB) {
+        return -1
+      } else if (differenceA > differenceB) {
+        return 1
+      }
+      return 0
+    })
+
+  const visibleElement = visibleElementsClosestToMiddle[0]
 
   const isEditable =
     sidebarBlocksMap[highlightTreePath] &&

--- a/react/components/HighlightOverlay/index.tsx
+++ b/react/components/HighlightOverlay/index.tsx
@@ -95,7 +95,10 @@ const HighlightOverlay: React.FC<Props> = props => {
   return (
     <>
       <CSSTransition
-        in={Boolean((hasValidElement && hasHighlight) || openBlockTreePath)}
+        in={
+          Boolean(hasValidElement && hasHighlight) ||
+          Boolean(hasValidElement && openBlockTreePath)
+        }
         classNames={classNames}
         mountOnEnter
         timeout={150}


### PR DESCRIPTION
#### What problem is this solving?

1. When you click to edit a block that isn't rendered, the Highlight appears in the last valid block, for example, when you hover over the `RIch Text` and click to edit the `Footer`, this is what happens:

![Screen Shot 2019-10-21 at 17 14 50](https://user-images.githubusercontent.com/10400340/67243218-7844ef00-f42d-11e9-9c50-c561f5bec994.png)

The Highlight appears on the `Rich Text` instead of disappearing.

2. Hovering over a block that is rendered as a list (e.g., `Product Summary` inside `Shelf`), the current criteria selects the first element that is in the screen, however it doesn't necessarily mean that it is **visible**. In the shelf's case, its container has a width with `overflow: hidden` that hides the first `Product Summary` in big resolutions:

![Screen Shot 2019-10-21 at 17 14 23](https://user-images.githubusercontent.com/10400340/67243448-ed182900-f42d-11e9-8a34-ee8a799d4371.png)

#### How should this be manually tested?

[Workspace](https://fixhighlight--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

![Screen Shot 2019-10-21 at 17 31 10](https://user-images.githubusercontent.com/10400340/67243502-120c9c00-f42e-11e9-80dc-671441235516.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/rwsjG8KzbbykE/giphy.gif)
