### PR TITLE
Fix: users not able to schedule content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Users were not able to schedule content because datepicker was not appearing
+  in full inside sidebar
+
 ## [4.14.1] - 2019-10-23
 
 ### Fixed
@@ -14,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - No option to "cancel" configuration delete
 
 ## [4.14.0] - 2019-10-23
+
 ### Added
 
 - Status label to configuration cards.

--- a/react/components/EditorContainer/Sidebar/Transitions/Enter/index.tsx
+++ b/react/components/EditorContainer/Sidebar/Transitions/Enter/index.tsx
@@ -13,10 +13,8 @@ const Enter: React.FC<EnterProps> = ({ children, condition, from }) => (
     classNames={{
       appear: styles[`transition-editor-enter-${from}`],
       appearActive: styles[`transition-editor-enter-${from}-active`],
-      appearDone: styles[`transition-editor-enter-${from}-done`],
       enter: styles[`transition-editor-enter-${from}`],
       enterActive: styles[`transition-editor-enter-${from}-active`],
-      enterDone: styles[`transition-editor-enter-${from}-done`],
     }}
     in={condition}
     mountOnEnter

--- a/react/components/EditorContainer/Sidebar/Transitions/Enter/styles.css
+++ b/react/components/EditorContainer/Sidebar/Transitions/Enter/styles.css
@@ -7,19 +7,11 @@
   transform: translateX(0);
 }
 
-.transition-editor-enter-left-done {
-  transform: translateX(0);
-}
-
 .transition-editor-enter-right {
   transform: translateX(18em);
 }
 
 .transition-editor-enter-right-active {
   transition: transform 250ms ease-in;
-  transform: translateX(0);
-}
-
-.transition-editor-enter-right-done {
   transform: translateX(0);
 }


### PR DESCRIPTION
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Users couldn't schedule content because datepicker was not visible in
the sidebar.

#### How should this be manually tested?

[Workspace](https://fixmodal--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes
The reason why I removed the transform property is because z-index does
not play well with it. Thus, in order to make z-index work, we have to
rely on the element not having a transform property.
<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/l4HohVwFLzHKcwa6A/giphy.gif)