### PR TITLE
Attemp to fix race condition in editor messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [4.14.2] - 2019-10-25
+### Fixed
+
+- Race condition when more than one messages batch was fetched from the server
 
 ### Fixed
 

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -36,7 +36,7 @@ const PageEditor: ComponentWithCustomMessage = (props: Props) => {
   const messagesContextValue = useMemo(
     () => ({
       setMessages(newMessages?: object) {
-        messages = newMessages || {}
+        messages = {...messages, ...newMessages}
       },
     }),
     []


### PR DESCRIPTION
#### What problem is this solving?
Race condition that makes editor keys load with i18n strings

#### How should this be manually tested?

[Workspace](https://gimenesrc--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
![Screen Shot 2019-10-28 at 15 53 59](https://user-images.githubusercontent.com/1354492/67708676-4e467c00-f99b-11e9-8352-a3f77b33108c.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/10peyLZ5GkErFC/giphy.gif)
