### PR TITLE
Removed option to set card to "this template"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed option to set configuration card to "this template"
+
 ## [4.14.3] - 2019-10-28
 
 ## [4.14.2] - 2019-10-25

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/ConditionControls/index.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/ConditionControls/index.tsx
@@ -18,7 +18,23 @@ interface Props {
   pageContext: RenderRuntime['route']['pageContext']
 }
 
-class ConditionControls extends PureComponent<Props> {
+interface State {
+  originalScope: ConfigurationScope
+}
+
+class ConditionControls extends PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      originalScope: this.props.isSitewide
+        ? 'sitewide'
+        : this.props.condition.pageContext.id === '*'
+        ? 'template'
+        : 'entity',
+    }
+  }
+
   private isScopeDisabled =
     this.props.isSitewide || isUnidentifiedPageContext(this.props.pageContext)
 
@@ -42,15 +58,19 @@ class ConditionControls extends PureComponent<Props> {
         </FormattedMessage>
 
         <div className="mv7 ph5">
-          <ScopeSelector
-            isDisabled={this.isScopeDisabled}
-            isSitewide={isSitewide}
-            onChange={this.handleScopeChange}
-            pageContext={pageContext}
-            scope={scope}
-          />
+          {this.state.originalScope === 'template' && (
+            <React.Fragment>
+              <ScopeSelector
+                isDisabled={this.isScopeDisabled}
+                isSitewide={isSitewide}
+                onChange={this.handleScopeChange}
+                pageContext={pageContext}
+                scope={scope}
+              />
 
-          <Separator />
+              <Separator />
+            </React.Fragment>
+          )}
 
           <Scheduler
             onConditionUpdate={this.handleDateChange}


### PR DESCRIPTION
#### What problem is this solving?
When editing a block configuration you will not see the option to set
the configuration to "this template" anymore.

This setting was causing confusion and could lead to complex scenarios
that were difficult to reason what configuration would be applied and
when.

The option to set content all templates is still available in the "app
card" which is the app the has the "created by app ..." in the name.

Whenever you create a configuration, you will be applying the changes
for the specific entity you are editing: the page, the brand, the
category, the product and so on so forth. 

If you want to create a change that affect all entities, you need only
edit the app card.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Try editing a block card.

If it is set to to "this template", you should still see the option to
change it to "this url".

If it is a new card or a old card taht is not set as "this template",
this option will not be visible anymore.

P.S.: the first rich-text has a bunch of template cards that you can use
to test.

[Workspace](https://ch25052--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
![this template](https://user-images.githubusercontent.com/1354492/67898499-3576cb80-fb3f-11e9-85df-221ac2ee975f.gif)


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️ | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3oKIPf3C7HqqYBVcCk/giphy.gif)