### PR TITLE
Add styles menu item to GoCommerce sidebar too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add styles menu item to GoCommerce sidebar too.
 
 ## [4.18.7] - 2020-01-06
 

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -34,6 +34,10 @@
         "path": "/admin/cms/site-editor"
       },
       {
+        "labelId": "admin/pages.admin-menu-button.styles",
+        "path": "/admin/cms/styles"
+      },
+      {
         "labelId": "admin/pages.admin-menu-button.pages",
         "path": "/admin/cms/content"
       }


### PR DESCRIPTION
#### What problem is this solving?

Add `styles` menu item into GoCommerce sidebar.

#### How should this be manually tested?

https://gustavo--gcqa.mygocommerce.com/admin/cms/styles

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| x | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |
