### PR TITLE
Fix layout instability when loading site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Layout instability when loading the site editor. The sidebar would take a few
+  seconds to appear and the page would undesirably resize
+
 ## [4.19.0] - 2020-01-09
 
 ### Added

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -8,7 +8,6 @@ import { ANIMATION_TIMEOUT } from '../../consts'
 import { useEditorContext } from '../../EditorContext'
 import Modal from '../../Modal'
 import SaveContentMutation from '../mutations/SaveContent'
-
 import AbsoluteLoader from './AbsoluteLoader'
 import BlockEditor from './BlockEditor'
 import BlockSelector from './BlockSelector'
@@ -61,11 +60,7 @@ const Sidebar: React.FunctionComponent<Props> = ({
   return (
     <div
       id="sidebar-vtex-editor"
-      className={
-        editor.isSidebarVisible
-          ? `z-1 h-100 ${styles['w-18em-ns']} w-100 flex flex-row-reverse`
-          : 'dn'
-      }
+      className={`z-1 h-100 ${styles['w-18em-ns']} w-100 flex flex-row-reverse`}
     >
       <nav
         id="admin-sidebar"

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -2,20 +2,16 @@ import debounce from 'lodash/debounce'
 import { path } from 'ramda'
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Alert, ToastConsumer } from 'vtex.styleguide'
+import { Alert, Spinner, ToastConsumer } from 'vtex.styleguide'
 
 import { State as HighlightOverlayState } from '../HighlightOverlay/typings'
-
 import Sidebar from './Sidebar'
 import { FormMetaProvider } from './Sidebar/FormMetaContext'
 import { ModalProvider } from './Sidebar/ModalContext'
-
 import IframeNavigationController from './IframeNavigationController'
 import Styles from './Styles'
 import Topbar from './Topbar'
-
 import styles from './EditorContainer.css'
-
 import '../../editbar.global.css'
 
 export const APP_CONTENT_ELEMENT_ID = 'app-content-editor'
@@ -112,26 +108,34 @@ const EditorContainer: React.FC<Props> = ({
     <FormMetaProvider>
       <ModalProvider>
         <IframeNavigationController iframeRuntime={iframeRuntime} />
-        <div className="w-100 h-100 min-vh-100 flex flex-row-reverse bg-base bb bw1 b--muted-5">
-          {isSiteEditor && iframeRuntime && (
-            <ToastConsumer>
-              {({ showToast }) => (
-                <Sidebar
-                  highlightHandler={highlightExtensionPoint}
-                  iframeRuntime={iframeRuntime}
-                  showToast={showToast}
-                  updateHighlightTitleByTreePath={
-                    updateHighlightTitleByTreePath
-                  }
-                />
-              )}
-            </ToastConsumer>
-          )}
+        <div className="w-500 h-100 min-vh-100 flex flex-row-reverse bg-base bb bw1 b--muted-5">
+          <div style={{ minWidth: '284px' }}>
+            {isSiteEditor && iframeRuntime ? (
+              <ToastConsumer>
+                {({ showToast }) => (
+                  <Sidebar
+                    highlightHandler={highlightExtensionPoint}
+                    iframeRuntime={iframeRuntime}
+                    showToast={showToast}
+                    updateHighlightTitleByTreePath={
+                      updateHighlightTitleByTreePath
+                    }
+                  />
+                )}
+              </ToastConsumer>
+            ) : (
+              <div className="bg-white-70 flex items-center h-100 justify-center w-100 z-2">
+                <Spinner />
+              </div>
+            )}
+          </div>
 
           <div className="w-100 dn flex-ns flex-column">
-            {isSiteEditor && iframeRuntime && (
-              <Topbar iframeRuntime={iframeRuntime} />
-            )}
+            <div style={{ minHeight: '64px' }} className="bg-muted-5">
+              {isSiteEditor && iframeRuntime && (
+                <Topbar iframeRuntime={iframeRuntime} />
+              )}
+            </div>
 
             {isDevelopment && (
               <div className="pa5 bg-muted-5">


### PR DESCRIPTION
#### What problem is this solving?
There is a significant layout instability when loading the site editor
that causes the site to be abruptly resized

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Load the site editor in the link below and verify that there is no
layout instability anymore.

[Workspace](https://nardi--storecomponents.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
![loading2](https://user-images.githubusercontent.com/1354492/72089007-05d80280-32ea-11ea-9992-7eb7a7f36304.gif)


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
|  ✔️   | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)