### PR TITLE
Fix: incorrect loading in styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- The styles admin was displaying a loading in the right side. This loading
+  animation was removed since there was nothing to be displayed there.
+
 ## [4.20.1] - 2020-01-16
 
 ### Fixed

--- a/react/components/EditorContainer/index.tsx
+++ b/react/components/EditorContainer/index.tsx
@@ -110,7 +110,11 @@ const EditorContainer: React.FC<Props> = ({
       <ModalProvider>
         <IframeNavigationController iframeRuntime={iframeRuntime} />
         <div className="vtex-admin-pages-4-x h-100 min-vh-100 flex flex-row-reverse bg-base bb bw1 b--muted-5">
-          <div className={editor.isSidebarVisible ? 'w-18em-ns' : 'dn'}>
+          <div
+            className={
+              editor.isSidebarVisible && isSiteEditor ? 'w-18em-ns' : 'dn'
+            }
+          >
             {isSiteEditor && iframeRuntime ? (
               <ToastConsumer>
                 {({ showToast }) => (


### PR DESCRIPTION
#### What problem is this solving?
The styles admin was displaying a loading in the right side. This loading
animation was removed since there was nothing to be displayed there.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Check that the loading does not appear in the right
[Workspace](https://nardi3--storecomponents.myvtex.com/admin/cms/styles)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/1Y7ChRtbWnYONjDidg/giphy.gif)