### PR TITLE
Save user routes as rewriter internal routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `dataSource` field to save user routes as rewriter internal routes
 
 ## [3.19.1] - 2020-04-01
 

--- a/react/PageForm.tsx
+++ b/react/PageForm.tsx
@@ -62,6 +62,7 @@ class PageForm extends Component<Props, State> {
     routeId: '',
     title: '',
     uuid: undefined,
+    dataSource: 'vtex.rewriter'
   }
 
   constructor(props: Props) {

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -255,6 +255,7 @@ class FormContainer extends Component<Props, State> {
         routeId,
         title,
         uuid,
+        dataSource,
       } = isUserRoute(this.props.initialData)
         ? this.state.data
         : {
@@ -310,6 +311,7 @@ class FormContainer extends Component<Props, State> {
                   ),
                 title,
                 uuid,
+                dataSource,
               },
             },
           })

--- a/react/queries/DeleteRoute.graphql
+++ b/react/queries/DeleteRoute.graphql
@@ -1,3 +1,3 @@
 mutation DeleteRoute($uuid: String!) {
-  deleteRoute(uuid: $uuid)
+  deleteRoute(uuid: $uuid, dataSource: "vtex.rewriter")
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -80,6 +80,7 @@ declare global {
     routeId: string
     title: string | null
     uuid?: string
+    dataSource?: string
   }
 
   interface Routes {


### PR DESCRIPTION
#### What problem is this solving?
User routes will be supported by render as rewriter internal routes.
This PR enables pages to store this routes in rewriter when the dataSource: 'vtex.rewriter' is given.

When dataSource is not provided we still save the routes in colossus, this decision was made to keep backwards compatibility for tenants that don't have rewriter.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

https://jey--samsungpeepp.myvtex.com/admin/cms/pages
1 - Add any landing page.
2 - Access it, it should work.
3.- Delete the new page added.

Screenshots or example usage


<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
