### PR TITLE
Detail binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses binding for listing/detailing redirects
 
 ## [4.24.0] - 2020-04-24
 ### Added

--- a/admin/routes.json
+++ b/admin/routes.json
@@ -19,7 +19,7 @@
   },
   "admin.app.cms.pages.redirect-details": {
     "component": "RedirectForm",
-    "path": "/admin/app/cms/redirects/*path"
+    "path": "/admin/app/cms/redirects/:binding/*path"
   },
   "admin.app.cms.content": {
     "component": "InstitutionalPageList",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "admin-pages",
-  "version": "4.24.0",
+  "version": "4.25.0-beta.0",
   "title": "VTEX Pages Admin",
   "description": "The VTEX Pages CMS admin interface",
   "builders": {

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -24,7 +24,8 @@ import Redirect from './queries/Redirect.graphql'
 
 interface CustomProps {
   params: {
-    path: string
+    path: string,
+    binding: string
   }
 }
 
@@ -75,7 +76,10 @@ class RedirectForm extends Component<Props, State> {
         const response = await client.query<RedirectQuery>({
           query: Redirect,
           variables: {
-            path: '/' + params.path,
+            locator: {
+              from: '/' + params.path,
+              binding: params.binding,
+            },
           },
         })
 

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -110,7 +110,6 @@ const List: React.FC<Props> = ({
     (event: { rowData: Redirect }) => {
       const selectedItem = event.rowData
       const to = join(BASE_URL, selectedItem.binding, selectedItem.from)
-      console.log(`navigating to ${to}`)
       navigate({ to })
     },
     [navigate]

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -7,6 +7,7 @@ import {
   Table,
   ToastConsumerFunctions,
 } from 'vtex.styleguide'
+import { join } from 'path'
 
 import { getFormattedLocalizedDate } from '../../../../utils/date'
 import { BASE_URL, NEW_REDIRECT_ID } from '../consts'
@@ -108,7 +109,9 @@ const List: React.FC<Props> = ({
   const handleItemView = useCallback(
     (event: { rowData: Redirect }) => {
       const selectedItem = event.rowData
-      navigate({ to: `${BASE_URL}${selectedItem.from}` })
+      const to = join(BASE_URL, selectedItem.binding, selectedItem.from)
+      console.log(`navigating to ${to}`)
+      navigate({ to })
     },
     [navigate]
   )

--- a/react/queries/Redirect.graphql
+++ b/react/queries/Redirect.graphql
@@ -1,10 +1,11 @@
-query Redirect($path: String!) {
+query Redirect($locator: RouteLocator!) {
   redirect @context(provider: "vtex.rewriter") {
-    get(path: $path) {
+    get(path: "", locator: $locator) {
       endDate
       from
       to
       type
+      binding
     }
   }
 }

--- a/react/queries/Redirects.graphql
+++ b/react/queries/Redirects.graphql
@@ -6,6 +6,7 @@ query Redirects($limit: Int, $next: String) {
         from
         to
         type
+        binding
       }
       next
     }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -280,6 +280,7 @@ declare global {
     from: string
     to: string
     type: RedirectTypes
+    binding: string
   }
 
   interface HighlightableIFrame extends HTMLIFrameElement {


### PR DESCRIPTION
#### What problem is this solving?
After changing rewriter's api to include binding, the redirects list/detail breaks if the store has more than on binding

#### How should this be manually tested?
Navigate in the redirects list and open the redirects detail. They should open normally

[Workspace](https://gimenesstable--miriadeit.myvtex.com/admin/cms/redirects/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/hpXFi66bfQm7e81ohw/giphy.gif)
