### PR TITLE
Remove changelog.md from .vtexignore

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -1,14 +1,10 @@
 .git
 src
-
 .gitignore
-CHANGELOG.md
 README.md
-
 **/.DS_Store
 **/node_modules
 **/yarn-error.log
-
 **/*.{spec,test}.{ts,tsx}
 **/tests/**
 **/__fixtures__/**


### PR DESCRIPTION
This an [automated pull request](https://github.com/vtex/github-pull-request-script) that aims to:

- Remove CHANGELOG.md from .vtexignore

When approved, feel free to merge it as if it was created by a bot account :robot:.

**#trivial**