### PR TITLE
Take querystring into account when loading iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- When accessing a specific page directly, the querystring was being ignored
 
 ## [4.24.1] - 2020-05-14
 ### Fixed

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -10,10 +10,16 @@ interface Props extends RenderContextProps {
   params: {
     targetPath: string
   }
+  query: Record<string, string>[]
 }
 
 const PageEditor: React.FC<Props> = props => {
-  const { page, params } = props
+  const { page, params, query } = props
+
+  const queryString = Object.entries(query).reduce(
+    (acc, [key, value]) => `${acc ? acc : '?'}${`${acc}&${key}=${value}`}`,
+    ''
+  )
 
   const runtime = useRuntime()
 
@@ -26,7 +32,7 @@ const PageEditor: React.FC<Props> = props => {
 
   const isSiteEditor = React.useMemo(() => page.includes('site-editor'), [page])
 
-  const path = params && params.targetPath
+  const path = params && `${params.targetPath}${queryString}`
 
   const { stopLoading } = useAdminLoadingContext()
 

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -9,7 +9,8 @@ const UrlInput = () => {
   const editor = useEditorContext()
 
   const urlPath = editor.iframeWindow
-    ? editor.iframeWindow.location.pathname
+    ? editor.iframeWindow.location.pathname +
+      editor.iframeWindow.location.search
     : ''
 
   const [url, setUrl] = React.useState(urlPath)

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -313,7 +313,9 @@ class EditorProvider extends Component<Props, State> {
     window.top.postMessage({ action: { type: 'START_LOADING' } }, '*')
 
     const convertedUrl = getUrlProperties(url)
-    const storePath = convertedUrl ? convertedUrl.pathname : url
+    const storePath = convertedUrl
+      ? `${convertedUrl.pathname}${convertedUrl.search}`
+      : url
     const pathname = /^\//.test(storePath) ? storePath : `/${storePath}`
 
     window.top.location.assign(`/admin/cms/site-editor${pathname}`)

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -314,7 +314,7 @@ class EditorProvider extends Component<Props, State> {
 
     const convertedUrl = getUrlProperties(url)
     const storePath = convertedUrl
-      ? `${convertedUrl.pathname}${convertedUrl.search}`
+      ? `${convertedUrl.pathname}${convertedUrl.search ?? ''}`
       : url
     const pathname = /^\//.test(storePath) ? storePath : `/${storePath}`
 


### PR DESCRIPTION
#### What problem is this solving?
Some pages will return 404 without querystring. Trying to edit those page won't work because Site Editor is not taking into account querystrings in the URL.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Make sure you see products when entering this workspace:
[Workspace](https://nardi--hushpuppiescl.myvtex.com/admin/cms/site-editor/289?map=productClusterIds)

While in production you won't be able to:
[Production](https://hushpuppiescl.myvtex.com/admin/cms/site-editor/289?map=productClusterIds)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
<img width="909" alt="Screen Shot 2020-06-18 at 14 27 25" src="https://user-images.githubusercontent.com/1354492/85053062-58a6c780-b170-11ea-8e01-e571ef476127.png">


#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/ozXTrqRgqFcly/giphy.gif)