### PR TITLE
Fix: undefined in the url path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `undefined` appearing in the URL path wouldn't allow page to be loaded
+
 ## [4.25.1] - 2020-06-29
 
 ### Fixed

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -17,11 +17,11 @@ const PageEditor: React.FC<Props> = props => {
   const { page, params, query } = props
 
   const queryString =
-    query !== undefined &&
-    Object.entries(query).reduce(
-      (acc, [key, value]) => `${acc ?? '?'}${`${acc}&${key}=${value}`}`,
-      ''
-    )
+    query === undefined || query === null
+      ? ''
+      : `?${Object.entries(query)
+          .map(([key, value]) => `${key}=${value}`)
+          .join('&')}`
 
   const runtime = useRuntime()
 

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -10,16 +10,18 @@ interface Props extends RenderContextProps {
   params: {
     targetPath: string
   }
-  query: Record<string, string>[]
+  query?: Record<string, string>[]
 }
 
 const PageEditor: React.FC<Props> = props => {
   const { page, params, query } = props
 
-  const queryString = Object.entries(query).reduce(
-    (acc, [key, value]) => `${acc ? acc : '?'}${`${acc}&${key}=${value}`}`,
-    ''
-  )
+  const queryString =
+    query !== undefined &&
+    Object.entries(query).reduce(
+      (acc, [key, value]) => `${acc ?? '?'}${`${acc}&${key}=${value}`}`,
+      ''
+    )
 
   const runtime = useRuntime()
 
@@ -32,7 +34,7 @@ const PageEditor: React.FC<Props> = props => {
 
   const isSiteEditor = React.useMemo(() => page.includes('site-editor'), [page])
 
-  const path = params && `${params.targetPath}${queryString}`
+  const path = params?.targetPath && `${params.targetPath}${queryString ?? ''}`
 
   const { stopLoading } = useAdminLoadingContext()
 


### PR DESCRIPTION
#### What problem is this solving?

Since latest relase (that wasn't deployed to all stores), when enterign in the home of a store, it would append `undefined` to it. This PR fixes that.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
You should be able to use Site Editor normally 
[Workspace](https://pathundefined--miriadeit.myvtex.com/admin/app/cms/site-editor)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/453QsWPQj5bsQaqp8M/giphy.gif)
