### PR TITLE
Fix: Some pages wouldnt allow conditional template

### DIFF
--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -13,7 +13,6 @@ import {
 import { formatStatements } from '../../../../utils/conditions'
 import { isNewRoute, isUserRoute } from '../utils'
 import { generateNewRouteId } from './utils'
-
 import Form from './Form'
 import {
   getAddConditionalTemplateState,
@@ -25,9 +24,7 @@ import {
   getValidateFormState,
 } from './stateHandlers'
 import { FormErrors } from './typings'
-
 import { OperationsResults } from './Operations'
-
 import { slugify } from '../../utils'
 
 interface ComponentProps {
@@ -255,13 +252,14 @@ class FormContainer extends Component<Props, State> {
         routeId,
         title,
         uuid,
-        dataSource
+        dataSource,
       } = isUserRoute(this.props.initialData)
         ? this.state.data
         : {
             ...(diff(this.props.initialData, this.state.data) as Partial<
               RouteFormData
             >),
+            pages: this.state.data.pages || this.state.data,
             declarer: this.state.data.declarer,
             domain: this.state.data.domain,
             path: this.state.data.path,
@@ -311,7 +309,7 @@ class FormContainer extends Component<Props, State> {
                   ),
                 title,
                 uuid,
-                dataSource
+                dataSource,
               },
             },
           })


### PR DESCRIPTION
#### What problem is this solving?
Pages with only one or two template variations for some reason were mutating
incorrectly. The property `pages` was supposed to be an array of Pages, but the
it looks like the `diff`  function is turning it into an object at runtime, and
thus Typescript cannot prevent it from happening.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Try adding a conditional template to Home here and it should work:
[Workspace](https://nardi--aldi.myvtex.com/admin/app/cms/pages)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
https://www.loom.com/share/ee5e109293754e829623dbce49e28182

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/gUnRTJ0zqHJRe/giphy.gif)