### PR TITLE
add binding field to redirects spreadsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `binding` to redirects export spreadsheet.
 
 ## [4.26.0] - 2020-07-16
 

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -133,9 +133,9 @@ const RedirectList: React.FC<Props> = ({ client, setTargetPath }) => {
       })
       const redirects = response.data.redirect.listRedirects.routes
       next = response.data.redirect.listRedirects.next
-      redirects.forEach(({ endDate, from, to, type }) => {
+      redirects.forEach(({ endDate, from, to, type, binding }) => {
         writer.write(
-          textEncoder.encode(`${from};${to};${type};${endDate || ''}\n`)
+          textEncoder.encode(`${from};${to};${type};${binding || ''};${endDate || ''}\n`)
         )
       })
     } while (next !== null)

--- a/react/components/admin/redirects/consts.ts
+++ b/react/components/admin/redirects/consts.ts
@@ -1,5 +1,5 @@
 export const BASE_URL = '/admin/app/cms/redirects'
-export const CSV_HEADER = 'from;to;type;endDate'
+export const CSV_HEADER = 'from;to;type;binding;endDate'
 export const CSV_SEPARATOR = ';'
 
 export const CSV_TEMPLATE = `${CSV_HEADER}

--- a/react/queries/Redirects.graphql
+++ b/react/queries/Redirects.graphql
@@ -6,6 +6,7 @@ query Redirects($limit: Int, $next: String) {
         from
         to
         type
+        binding
       }
       next
     }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -280,6 +280,7 @@ declare global {
     from: string
     to: string
     type: RedirectTypes
+    binding: string | null
   }
 
   interface HighlightableIFrame extends HTMLIFrameElement {


### PR DESCRIPTION
#### What problem is this solving?

Users want to see the spreadsheet with the binding field to know to what binding that redirect belongs to.

#### How should this be manually tested?

https://fidelis--powerplanet.myvtex.com/admin/cms/redirects/

click on exportar and check the result.

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
