### PR TITLE
Uses querystring to query redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses querystring to get the redirect
 
 ## [4.27.0] - 2020-07-21 [YANKED]
 ### Added

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -72,7 +72,7 @@ class RedirectForm extends Component<Props, State> {
 
     if (!formData) {
       try {
-        const querystring = history?.location?.search || ''
+        const querystring = history?.location?.search ?? ''
         const response = await client.query<RedirectQuery>({
           query: Redirect,
           variables: {

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -63,7 +63,7 @@ class RedirectForm extends Component<Props, State> {
     const {
       client,
       params,
-      runtime: { navigate },
+      runtime: { navigate, history },
       setTargetPath,
     } = this.props
     const { formData } = this.state
@@ -72,10 +72,11 @@ class RedirectForm extends Component<Props, State> {
 
     if (!formData) {
       try {
+        const querystring = history?.location?.search || ''
         const response = await client.query<RedirectQuery>({
           query: Redirect,
           variables: {
-            path: '/' + params.path,
+            path: `/${params.path}${querystring}`,
           },
         })
 


### PR DESCRIPTION
#### What problem is this solving?
Currently the redirect form component is not taking into account the redirect query string when querying rewriter. This PR fixes that

#### How should this be manually tested?

You can create a redirect with query strings in the `FROM` path, when trying to edit the redirect the form will not render.
Test workspace:

https://fox2--fashion2.myvtex.com/admin/cms/redirects/a/?v=12

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
