### PR TITLE
Force template date to be midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Templates scheduled to go live in a specific day now always go live at midnight
 
 ## [4.27.2] - 2020-09-30
 ### Added

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -9,14 +9,15 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
 
   useEffect(() => {
     if (iframeRef && iframeRef.current && iframeRef.current.contentWindow) {
-      const oldLog = iframeRef.current.contentWindow.console.log
-      const oldError = iframeRef.current.contentWindow.console.error
-      iframeRef.current.contentWindow.console.log = function newLog() {
+      const oldLog = (iframeRef.current.contentWindow as any).console.log
+      const oldError = (iframeRef.current.contentWindow as any).console.error
+      ;(iframeRef.current
+        .contentWindow as any).console.log = function newLog() {
         Array.prototype.unshift.call(arguments, `[Iframe]: `)
         oldLog.apply(this, arguments)
       }
-
-      iframeRef.current.contentWindow.console.error = function newError() {
+      ;(iframeRef.current
+        .contentWindow as any).console.error = function newError() {
         Array.prototype.unshift.call(arguments, `[Iframe]: `)
         oldError.apply(this, arguments)
       }

--- a/react/components/admin/pages/Form/SelectConditions.tsx
+++ b/react/components/admin/pages/Form/SelectConditions.tsx
@@ -137,9 +137,15 @@ class SelectConditions extends React.Component<Props> {
         value={values && values.date}
         onChange={(date: Date) => {
           const newStatements = statements.map((statement, index) => {
+            const dateAtMidnight = new Date(date)
+            dateAtMidnight.setHours(0, 0, 0, 0)
+
             return {
               ...statement,
-              object: index === statementIndex ? { date } : statement.object,
+              object:
+                index === statementIndex
+                  ? { date: dateAtMidnight }
+                  : statement.object,
             }
           })
           this.props.onChangeStatements(newStatements)

--- a/react/components/form/ImageUploader/Dropzone.tsx
+++ b/react/components/form/ImageUploader/Dropzone.tsx
@@ -7,7 +7,7 @@ interface Props {
   extraClasses?: string
   onClick: React.MouseEventHandler<HTMLElement>
   onDrop: DropzoneOptions['onDrop']
-  ref?: React.RefObject<HTMLDivElement>
+  ref?: React.Ref<HTMLDivElement>
 }
 
 const MAX_SIZE = 4 * 1024 * 1024

--- a/react/utils/components/index.ts
+++ b/react/utils/components/index.ts
@@ -111,7 +111,7 @@ export const getComponentSchema = ({
     return adaptedComponentSchema
   }
 
-  return mergeDeepRight(adaptedComponentSchema, contentSchema)
+  return mergeDeepRight(adaptedComponentSchema, contentSchema) as any
 }
 
 export const getExtension = (


### PR DESCRIPTION
#### What problem is this solving?
The time that a template went online was not consistent. With this update, the time a page with be scheduled will be midnight of the day selected. And the time will be based on the user's timezone.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/8bqAQNPfigzuM/giphy.gif)
