### PR TITLE
Fix/pages block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Sending blockId in `Form index` component even when is not changed to prevent unexpected behaviors
 
 ## [4.31.0] - 2021-01-13
 ### Added

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -237,6 +237,7 @@ class FormContainer extends Component<Props, State> {
     event.preventDefault()
 
     const nextState = getValidateFormState(this.state)
+
     if (isEmpty(nextState.formErrors)) {
       const {
         auth,
@@ -262,6 +263,7 @@ class FormContainer extends Component<Props, State> {
             pages: this.state.data.pages || this.state.data,
             declarer: this.state.data.declarer,
             domain: this.state.data.domain,
+            blockId: this.state.data.blockId || this.props.initialData,
             path: this.state.data.path,
             routeId: this.state.data.routeId,
             uuid: this.state.data.uuid,


### PR DESCRIPTION
#### What problem is this solving?

We got an unexpected behavior when not switching blockID sending undefined in [this workspace](https://lhx--eriksbikeshop.myvtex.com/admin/cms/pages/store.home/) switching to another theme and not maintaining the previous one. To avoid this, I will always pass blockID to the query, even when not changed

Go to admin => CMS => pages => choose one and try to save, if it works, then, it's fine

You can test the behavior of this PR in this [Workspace](https://iespinoza--eriksbikeshop.myvtex.com/admin/cms/pages/store.home/)

#### Type of changes

<!--- Add a ✔️ where applicable -->

|       | Type of Change                                                                            |
| --- | ------------------------------------------------------------------------------------------|
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                                                    |
|       | New feature <!-- a non-breaking change which adds functionality -->                                   |
|       | Breaking change <!-- fix or feature that would cause existing functionality to change -->   |
|       | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

Probably this was made this way because the API send a PUT and don't want to change if it's any new information, don't how it works in under the hood, but this change prevents unexpected behaviors

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3oxHQhskfeO5WcgvlK/giphy.gif)
