### PR TITLE
Add site editor flag in the iframe url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Site editor flag in the iframe url.
+- Site editor flag in the iframe URL.
 
 ## [4.32.0] - 2021-01-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Site editor flag in the iframe url.
+
 ## [4.32.0] - 2021-01-21
 ### Added
 - Adds binding selector for CMS Pages 
@@ -16,7 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sending blockId in `Form index` component even when is not changed to prevent unexpected behaviors
 
 ## [4.31.0] - 2021-01-13
+
 ### Added
+
 - Keep selected binding between admin reloads.
 
 ## [4.30.0] - 2020-12-14

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -28,15 +28,15 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
     }
   }, [])
 
-  const getJoiner = () => (src.includes('?') ? '&' : '?')
+  const getJoiner = (src: string) => (src.includes('?') ? '&' : '?')
 
   let src = path ? `/${path}` : '/'
 
   if (binding && !src.includes('__bindingAddress')) {
-    src += `${getJoiner()}__bindingAddress=${binding.canonicalBaseAddress}`
+    src += `${getJoiner(src)}__bindingAddress=${binding.canonicalBaseAddress}`
   }
 
-  src += `${getJoiner()}__siteEditor`
+  src += `${getJoiner(src)}__siteEditor`
 
   return (
     <iframe

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -28,11 +28,15 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
     }
   }, [])
 
+  const getJoiner = () => (src.includes('?') ? '&' : '?')
+
   let src = path ? `/${path}` : '/'
+
   if (binding && !src.includes('__bindingAddress')) {
-    const joiner = src.includes('?') ? '&' : '?'
-    src += `${joiner}__bindingAddress=${binding.canonicalBaseAddress}`
+    src += `${getJoiner()}__bindingAddress=${binding.canonicalBaseAddress}`
   }
+
+  src += `${getJoiner()}__siteEditor`
 
   return (
     <iframe


### PR DESCRIPTION
#### What problem is this solving?

  The `render-server` does not know where the page is being rendered, the iframe flag will help to identify it.

<!--- What is the motivation and context for this change? -->

Some site editor blocks sometimes disappear because of performance features and we need a way of recognizing where the page is being rendered.

#### How should this be manually tested?

1. Access the [workspace](https://vitorflg2--muji.myvtex.com/admin/cms/site-editor)
2. All the blocks should be identified by the block selector

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️ | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

X