### PR TITLE
Adds binding information in Redirects UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Adds binding selector for CMS Redirects
 
 ## [4.34.0] - 2021-01-22
 

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -120,13 +120,16 @@ class RedirectForm extends Component<Props, State> {
     } else {
       if (!formData.binding) {
         formData.binding = storeBindings[0].id
+        this.setState({
+          formData,
+        })
       }
     }
   }
 
   public render() {
     const { intl, params } = this.props
-    const { formData, isLoading } = this.state
+    const { formData, isLoading, storeBindings } = this.state
 
     return (
       <>
@@ -153,7 +156,7 @@ class RedirectForm extends Component<Props, State> {
                       onDelete={deleteRedirect}
                       onSave={saveRedirect}
                       showToast={showToast}
-                      // storeBindings={storeBindings}
+                      storeBindings={storeBindings}
                     />
                   </Box>
                 )}

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -43,6 +43,7 @@ interface State {
   formData?: Redirect
   isLoading: boolean
   storeBindings: Binding[] | null
+  isNew: boolean
 }
 
 class RedirectForm extends Component<Props, State> {
@@ -63,6 +64,7 @@ class RedirectForm extends Component<Props, State> {
       formData: isNew ? defaultFormData : undefined,
       isLoading: isNew ? false : true,
       storeBindings: null,
+      isNew,
     }
   }
 
@@ -133,7 +135,7 @@ class RedirectForm extends Component<Props, State> {
 
   public render() {
     const { intl, params } = this.props
-    const { formData, isLoading, storeBindings } = this.state
+    const { formData, isLoading, storeBindings, isNew } = this.state
 
     return (
       <>
@@ -161,6 +163,7 @@ class RedirectForm extends Component<Props, State> {
                       onSave={saveRedirect}
                       showToast={showToast}
                       storeBindings={storeBindings}
+                      isNew={isNew}
                     />
                   </Box>
                 )}

--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -7,6 +7,7 @@ import {
 import { Helmet, withRuntimeContext } from 'vtex.render-runtime'
 import { Box, ToastConsumer } from 'vtex.styleguide'
 import { Binding, Tenant } from 'vtex.tenant-graphql'
+import queryString from 'query-string'
 
 import {
   BASE_URL,
@@ -90,14 +91,17 @@ class RedirectForm extends Component<Props, State> {
 
     if (!formData) {
       try {
-        const querystring = history?.location?.search ?? ''
-        const [bindingId, ...rest] = params.path.split('/')
-        const path = rest.join('/')
+        const rawQuerystring = history?.location?.search ?? ''
+        const querystring = queryString.parse(rawQuerystring)
+        const { binding, ...rest } = querystring
+        const restQuerystring = queryString.stringify(rest)
         const response = await client.query<RedirectQuery>({
           query: Redirect,
           variables: {
-            path: `/${path}${querystring}`,
-            binding: bindingId,
+            path: `/${params.path}${
+              restQuerystring ? '?' + restQuerystring : ''
+            }`,
+            binding: binding,
           },
         })
 

--- a/react/components/admin/redirects/Form/index.tsx
+++ b/react/components/admin/redirects/Form/index.tsx
@@ -155,7 +155,7 @@ class Form extends Component<Props, State> {
           isActionDanger
           isActionLoading={isLoading}
           isOpen={shouldShowModal}
-          onClickAction={this.handleDelete(data.from)}
+          onClickAction={this.handleDelete(data.from, data.binding)}
           onClickCancel={this.handleModalVisibilityToggle}
           onClose={this.handleModalVisibilityToggle}
           textButtonAction={intl.formatMessage(messages.buttonRemove)}
@@ -312,7 +312,10 @@ class Form extends Component<Props, State> {
     this.props.runtime.navigate({ to: BASE_URL })
   }
 
-  private handleDelete = (redirectFrom: string) => () => {
+  private handleDelete = (
+    redirectFrom: string,
+    redirectBinding: string
+  ) => () => {
     const { intl, onDelete } = this.props
 
     this.setState({ isLoading: true }, async () => {
@@ -320,6 +323,7 @@ class Form extends Component<Props, State> {
         await onDelete({
           variables: {
             path: redirectFrom,
+            binding: redirectBinding,
           },
         })
 

--- a/react/components/admin/redirects/Form/index.tsx
+++ b/react/components/admin/redirects/Form/index.tsx
@@ -33,6 +33,7 @@ interface CustomProps {
   onDelete: DeleteRedirectMutationFn
   onSave: SaveRedirectMutationFn
   storeBindings: Binding[] | null
+  isNew: boolean
 }
 
 type Props = CustomProps &
@@ -138,7 +139,7 @@ class Form extends Component<Props, State> {
 
   public render() {
     const { locale } = this.context.culture
-    const { intl, storeBindings } = this.props
+    const { intl, storeBindings, isNew } = this.props
     const {
       data,
       isLoading,
@@ -180,7 +181,7 @@ class Form extends Component<Props, State> {
           <BindingSelectorWrapper visible={storeBindings.length > 1}>
             <Dropdown
               label={intl.formatMessage(messages.bindingSelectorTitle)}
-              disabled={storeBindings.length === 1}
+              disabled={!isNew || storeBindings.length === 1}
               onChange={this.handleBindingChange}
               options={bindingOptions}
               value={data.binding || storeBindings[0]}

--- a/react/components/admin/redirects/Form/index.tsx
+++ b/react/components/admin/redirects/Form/index.tsx
@@ -350,7 +350,7 @@ class Form extends Component<Props, State> {
   private handleSave = (event: React.FormEvent) => {
     const { intl, onSave } = this.props
     const {
-      data: { endDate, from, to, type },
+      data: { endDate, from, to, type, binding },
     } = this.state
 
     event.preventDefault()
@@ -363,6 +363,7 @@ class Form extends Component<Props, State> {
             from,
             to,
             type,
+            binding,
           },
         })
 

--- a/react/components/admin/redirects/Form/typings.d.ts
+++ b/react/components/admin/redirects/Form/typings.d.ts
@@ -18,6 +18,7 @@ export interface RedirectQuery {
 
 export interface DeleteRedirectVariables {
   path: string
+  binding?: string
 }
 
 export interface SaveRedirectVariables {

--- a/react/components/admin/redirects/Form/typings.d.ts
+++ b/react/components/admin/redirects/Form/typings.d.ts
@@ -26,6 +26,7 @@ export interface SaveRedirectVariables {
   from: string
   to: string
   type: RedirectTypes
+  binding?: string
 }
 
 interface Mutations {

--- a/react/components/admin/redirects/Form/utils.ts
+++ b/react/components/admin/redirects/Form/utils.ts
@@ -46,7 +46,8 @@ export const getStoreUpdater: StoreUpdaterGetter = operation => (
           : saveRedirect &&
             queryData.redirect.list.reduce(
               (acc, currRedirect) =>
-                currRedirect.from === saveRedirect.from
+                currRedirect.from === saveRedirect.from &&
+                currRedirect.binding === saveRedirect.binding
                   ? acc
                   : [...acc, currRedirect],
               [saveRedirect]
@@ -70,14 +71,20 @@ export const getStoreUpdater: StoreUpdaterGetter = operation => (
   }
 
   try {
+    const variables = isDelete
+      ? deleteRedirect && {
+          path: deleteRedirect.from,
+          binding: deleteRedirect.binding,
+        }
+      : saveRedirect && {
+          path: saveRedirect.from,
+          binding: saveRedirect.binding,
+        }
+
     store.writeQuery({
       data: { redirect: isDelete ? undefined : { save: saveRedirect } },
       query: Redirect,
-      variables: {
-        path: isDelete
-          ? deleteRedirect && deleteRedirect.from
-          : saveRedirect && saveRedirect.from,
-      },
+      variables,
     })
   } catch (e) {
     console.error('Error writing to "Redirect".')

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -125,13 +125,16 @@ const List: React.FC<Props> = ({
 
   useEffect(() => {
     setSchema(getSchema(intl, culture.locale, storeBindings))
-  }, [culture.locale, from, intl, loading])
+  }, [culture.locale, from, intl, loading, storeBindings])
 
   const handleItemView = useCallback(
     (event: { rowData: Redirect }) => {
       const selectedItem = event.rowData
+      const bindingQS = selectedItem.from.includes('?')
+        ? `&binding=${selectedItem.binding}`
+        : `?binding=${selectedItem.binding}`
       navigate({
-        to: `${BASE_URL}/${selectedItem.binding}${selectedItem.from}`,
+        to: `${BASE_URL}${selectedItem.from}${bindingQS}`,
       })
     },
     [navigate]

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -130,7 +130,9 @@ const List: React.FC<Props> = ({
   const handleItemView = useCallback(
     (event: { rowData: Redirect }) => {
       const selectedItem = event.rowData
-      navigate({ to: `${BASE_URL}${selectedItem.from}` })
+      navigate({
+        to: `${BASE_URL}/${selectedItem.binding}${selectedItem.from}`,
+      })
     },
     [navigate]
   )

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import { FormattedMessage, IntlShape, useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
+import {
+  ButtonWithIcon,
+  IconUpload,
+  Table,
+  ToastConsumerFunctions,
+} from 'vtex.styleguide'
+
+import { getFormattedLocalizedDate } from '../../../../utils/date'
+import { BASE_URL, NEW_REDIRECT_ID } from '../consts'
+import CreateButton from './CreateButton'
+import { messages } from './messages'
+
+interface CustomProps {
+  from: number
+  items: Redirect[]
+  loading: boolean
+  onHandleDownload: () => void
+  openModal: () => void
+  refetch: () => void
+  showToast: ToastConsumerFunctions['showToast']
+  to: number
+}
+
+export type Props = CustomProps
+
+interface Schema {
+  properties: object
+}
+
+function getSchema(intl: IntlShape, locale: string) {
+  const bindingProperty = {
+    binding: {
+      title: intl.formatMessage(messages.tableBinding),
+      type: 'string',
+    },
+  }
+
+  return {
+    properties: {
+      from: {
+        title: intl.formatMessage(messages.tableFrom),
+        type: 'string',
+      },
+      to: {
+        title: intl.formatMessage(messages.tableTo),
+        type: 'string',
+      },
+      type: {
+        title: intl.formatMessage(messages.tableType),
+        type: 'string',
+        cellRenderer: function Type(cell: { cellData: string }) {
+          return cell.cellData && cell.cellData === 'temporary' ? (
+            <FormattedMessage
+              id="admin/pages.admin.redirects.table.type.temporary"
+              defaultMessage="Temporary (302)"
+            >
+              {text => <span className="ph4">{text}</span>}
+            </FormattedMessage>
+          ) : (
+            <FormattedMessage
+              id="admin/pages.admin.redirects.table.type.permanent"
+              defaultMessage="Permanent (301)"
+            >
+              {text => <span className="ph4 silver">{text}</span>}
+            </FormattedMessage>
+          )
+        },
+      },
+      endDate: {
+        cellRenderer: function EndDate(cell: { cellData: string }) {
+          cell.cellData ? (
+            <span className="ph4">
+              {getFormattedLocalizedDate(cell.cellData, locale)}
+            </span>
+          ) : (
+            <FormattedMessage
+              id="admin/pages.admin.redirects.table.endDate.default"
+              defaultMessage="not set"
+            >
+              {text => <span className="ph4 silver">{text}</span>}
+            </FormattedMessage>
+          )
+        },
+        title: intl.formatMessage(messages.endDateTitle),
+        type: 'string',
+      },
+      ...bindingProperty,
+    },
+  }
+}
+
+const List: React.FC<Props> = ({
+  from,
+  items,
+  loading,
+  onHandleDownload,
+  openModal,
+}) => {
+  const { culture, navigate } = useRuntime()
+  const intl = useIntl()
+
+  const [schema, setSchema] = useState<Schema>(() =>
+    getSchema(intl, culture.locale)
+  )
+
+  useEffect(() => {
+    window.top.postMessage({ action: { type: 'STOP_LOADING' } }, '*')
+  }, [])
+
+  useEffect(() => {
+    setSchema(getSchema(intl, culture.locale))
+  }, [culture.locale, from, intl, loading])
+
+  const handleItemView = useCallback(
+    (event: { rowData: Redirect }) => {
+      const selectedItem = event.rowData
+      navigate({ to: `${BASE_URL}${selectedItem.from}` })
+    },
+    [navigate]
+  )
+
+  const handleNewItemOpen = useCallback(() => {
+    navigate({ to: `${BASE_URL}/${NEW_REDIRECT_ID}` })
+  }, [navigate])
+
+  return (
+    <Table
+      fullWidth
+      loading={loading}
+      items={items}
+      onRowClick={handleItemView}
+      schema={schema}
+      emptyStateLabel=""
+      emptyStateChildren={
+        <div className="pt5 flex flex-column tc">
+          <div>
+            <CreateButton onClick={handleNewItemOpen} />
+          </div>
+          <p className="mv2">
+            <FormattedMessage
+              id="admin/pages.admin.redirects.or.text"
+              defaultMessage="or"
+            />
+          </p>
+          <div>
+            <ButtonWithIcon
+              icon={<IconUpload />}
+              variation="secondary"
+              onClick={openModal}
+              size="small"
+            >
+              <FormattedMessage
+                id="admin/pages.admin.redirects.emptyState.upload"
+                defaultMessage="Upload a CSV"
+              />
+            </ButtonWithIcon>
+          </div>
+        </div>
+      }
+      toolbar={{
+        density: {
+          buttonLabel: intl.formatMessage(messages.lineDensityLabel),
+          highOptionLabel: intl.formatMessage(messages.lineDensityHigh),
+          lowOptionLabel: intl.formatMessage(messages.lineDensityLow),
+          mediumOptionLabel: intl.formatMessage(messages.lineDensityMedium),
+        },
+        download: {
+          disabled: items.length === 0,
+          handleCallback: onHandleDownload,
+          label: intl.formatMessage(messages.download),
+        },
+        fields: {
+          hideAllLabel: intl.formatMessage(messages.hideAll),
+          label: intl.formatMessage(messages.fieldsLabel),
+          showAllLabel: intl.formatMessage(messages.showAll),
+        },
+        newLine: {
+          handleCallback: handleNewItemOpen,
+          label: intl.formatMessage(messages.newLine),
+        },
+        upload: {
+          handleCallback: openModal,
+          label: intl.formatMessage(messages.upload),
+        },
+      }}
+    />
+  )
+}
+
+export default List

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -7,6 +7,7 @@ import {
   Table,
   ToastConsumerFunctions,
 } from 'vtex.styleguide'
+import { Binding } from 'vtex.tenant-graphql'
 
 import { getFormattedLocalizedDate } from '../../../../utils/date'
 import { BASE_URL, NEW_REDIRECT_ID } from '../consts'
@@ -22,6 +23,7 @@ interface CustomProps {
   refetch: () => void
   showToast: ToastConsumerFunctions['showToast']
   to: number
+  storeBindings: Binding[]
 }
 
 export type Props = CustomProps

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -1,193 +1,20 @@
-import React, { useEffect, useState, useCallback } from 'react'
-import { FormattedMessage, IntlShape, useIntl } from 'react-intl'
-import { useRuntime } from 'vtex.render-runtime'
-import {
-  ButtonWithIcon,
-  IconUpload,
-  Table,
-  ToastConsumerFunctions,
-} from 'vtex.styleguide'
+import React from 'react'
+import { Query } from 'react-apollo'
+import { Tenant } from 'vtex.tenant-graphql'
 
-import { getFormattedLocalizedDate } from '../../../../utils/date'
-import { BASE_URL, NEW_REDIRECT_ID } from '../consts'
-import CreateButton from './CreateButton'
-import { messages } from './messages'
+import Loader from '../../../Loader'
+import List, { Props } from './List'
+import TenantInfo from '../../../../queries/TenantInfo.graphql'
 
-interface CustomProps {
-  from: number
-  items: Redirect[]
-  loading: boolean
-  onHandleDownload: () => void
-  openModal: () => void
-  refetch: () => void
-  showToast: ToastConsumerFunctions['showToast']
-  to: number
-}
-
-export type Props = CustomProps
-
-interface Schema {
-  properties: object
-}
-
-function getSchema(intl: IntlShape, locale: string) {
-  const bindingProperty = {
-    binding: {
-      title: intl.formatMessage(messages.tableBinding),
-      type: 'string',
-    },
-  }
-
-  return {
-    properties: {
-      from: {
-        title: intl.formatMessage(messages.tableFrom),
-        type: 'string',
-      },
-      to: {
-        title: intl.formatMessage(messages.tableTo),
-        type: 'string',
-      },
-      type: {
-        title: intl.formatMessage(messages.tableType),
-        type: 'string',
-        cellRenderer: function Type(cell: { cellData: string }) {
-          return cell.cellData && cell.cellData === 'temporary' ? (
-            <FormattedMessage
-              id="admin/pages.admin.redirects.table.type.temporary"
-              defaultMessage="Temporary (302)"
-            >
-              {text => <span className="ph4">{text}</span>}
-            </FormattedMessage>
-          ) : (
-            <FormattedMessage
-              id="admin/pages.admin.redirects.table.type.permanent"
-              defaultMessage="Permanent (301)"
-            >
-              {text => <span className="ph4 silver">{text}</span>}
-            </FormattedMessage>
-          )
-        },
-      },
-      endDate: {
-        cellRenderer: function EndDate(cell: { cellData: string }) {
-          cell.cellData ? (
-            <span className="ph4">
-              {getFormattedLocalizedDate(cell.cellData, locale)}
-            </span>
-          ) : (
-            <FormattedMessage
-              id="admin/pages.admin.redirects.table.endDate.default"
-              defaultMessage="not set"
-            >
-              {text => <span className="ph4 silver">{text}</span>}
-            </FormattedMessage>
-          )
-        },
-        title: intl.formatMessage(messages.endDateTitle),
-        type: 'string',
-      },
-      ...bindingProperty,
-    },
-  }
-}
-
-const List: React.FC<Props> = ({
-  from,
-  items,
-  loading,
-  onHandleDownload,
-  openModal,
-}) => {
-  const { culture, navigate } = useRuntime()
-  const intl = useIntl()
-
-  const [schema, setSchema] = useState<Schema>(() =>
-    getSchema(intl, culture.locale)
-  )
-
-  useEffect(() => {
-    window.top.postMessage({ action: { type: 'STOP_LOADING' } }, '*')
-  }, [])
-
-  useEffect(() => {
-    setSchema(getSchema(intl, culture.locale))
-  }, [culture.locale, from, intl, loading])
-
-  const handleItemView = useCallback(
-    (event: { rowData: Redirect }) => {
-      const selectedItem = event.rowData
-      navigate({ to: `${BASE_URL}${selectedItem.from}` })
-    },
-    [navigate]
-  )
-
-  const handleNewItemOpen = useCallback(() => {
-    navigate({ to: `${BASE_URL}/${NEW_REDIRECT_ID}` })
-  }, [navigate])
-
+const ListWrapper: React.FC<Props> = props => {
   return (
-    <Table
-      fullWidth
-      loading={loading}
-      items={items}
-      onRowClick={handleItemView}
-      schema={schema}
-      emptyStateLabel=""
-      emptyStateChildren={
-        <div className="pt5 flex flex-column tc">
-          <div>
-            <CreateButton onClick={handleNewItemOpen} />
-          </div>
-          <p className="mv2">
-            <FormattedMessage
-              id="admin/pages.admin.redirects.or.text"
-              defaultMessage="or"
-            />
-          </p>
-          <div>
-            <ButtonWithIcon
-              icon={<IconUpload />}
-              variation="secondary"
-              onClick={openModal}
-              size="small"
-            >
-              <FormattedMessage
-                id="admin/pages.admin.redirects.emptyState.upload"
-                defaultMessage="Upload a CSV"
-              />
-            </ButtonWithIcon>
-          </div>
-        </div>
-      }
-      toolbar={{
-        density: {
-          buttonLabel: intl.formatMessage(messages.lineDensityLabel),
-          highOptionLabel: intl.formatMessage(messages.lineDensityHigh),
-          lowOptionLabel: intl.formatMessage(messages.lineDensityLow),
-          mediumOptionLabel: intl.formatMessage(messages.lineDensityMedium),
-        },
-        download: {
-          disabled: items.length === 0,
-          handleCallback: onHandleDownload,
-          label: intl.formatMessage(messages.download),
-        },
-        fields: {
-          hideAllLabel: intl.formatMessage(messages.hideAll),
-          label: intl.formatMessage(messages.fieldsLabel),
-          showAllLabel: intl.formatMessage(messages.showAll),
-        },
-        newLine: {
-          handleCallback: handleNewItemOpen,
-          label: intl.formatMessage(messages.newLine),
-        },
-        upload: {
-          handleCallback: openModal,
-          label: intl.formatMessage(messages.upload),
-        },
+    <Query<{ tenantInfo: Tenant }> query={TenantInfo}>
+      {({ data, loading: isLoading }) => {
+        const tenantInfo = data?.tenantInfo
+        return isLoading || !tenantInfo ? <Loader /> : <List {...props} />
       }}
-    />
+    </Query>
   )
 }
 
-export default List
+export default ListWrapper

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -31,6 +31,13 @@ interface Schema {
 }
 
 function getSchema(intl: IntlShape, locale: string) {
+  const bindingProperty = {
+    binding: {
+      title: intl.formatMessage(messages.tableBinding),
+      type: 'string',
+    },
+  }
+
   return {
     properties: {
       from: {
@@ -80,6 +87,7 @@ function getSchema(intl: IntlShape, locale: string) {
         title: intl.formatMessage(messages.endDateTitle),
         type: 'string',
       },
+      ...bindingProperty,
     },
   }
 }
@@ -93,6 +101,7 @@ const List: React.FC<Props> = ({
 }) => {
   const { culture, navigate } = useRuntime()
   const intl = useIntl()
+
   const [schema, setSchema] = useState<Schema>(() =>
     getSchema(intl, culture.locale)
   )

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -5,13 +5,18 @@ import { Tenant } from 'vtex.tenant-graphql'
 import Loader from '../../../Loader'
 import List, { Props } from './List'
 import TenantInfo from '../../../../queries/TenantInfo.graphql'
+import { getStoreBindings } from '../../../../utils/bindings'
 
 const ListWrapper: React.FC<Props> = props => {
   return (
     <Query<{ tenantInfo: Tenant }> query={TenantInfo}>
       {({ data, loading: isLoading }) => {
         const tenantInfo = data?.tenantInfo
-        return isLoading || !tenantInfo ? <Loader /> : <List {...props} />
+        if (isLoading || !tenantInfo) {
+          return <Loader />
+        }
+        const storeBindings = getStoreBindings(tenantInfo)
+        return <List {...props} storeBindings={storeBindings} />
       }}
     </Query>
   )

--- a/react/components/admin/redirects/List/index.tsx
+++ b/react/components/admin/redirects/List/index.tsx
@@ -7,7 +7,7 @@ import List, { Props } from './List'
 import TenantInfo from '../../../../queries/TenantInfo.graphql'
 import { getStoreBindings } from '../../../../utils/bindings'
 
-const ListWrapper: React.FC<Props> = props => {
+const ListWrapper: React.FC<Omit<Props, 'storeBindings'>> = props => {
   return (
     <Query<{ tenantInfo: Tenant }> query={TenantInfo}>
       {({ data, loading: isLoading }) => {

--- a/react/components/admin/redirects/List/messages.tsx
+++ b/react/components/admin/redirects/List/messages.tsx
@@ -61,4 +61,8 @@ export const messages = defineMessages({
     defaultMessage: 'Import',
     id: 'admin/pages.admin.redirects.table.toolbar.import',
   },
+  tableBinding: {
+    defaultMessage: 'Binding',
+    id: 'admin/pages.admin.redirects.table.binding',
+  },
 })

--- a/react/package.json
+++ b/react/package.json
@@ -33,6 +33,7 @@
     "json-schema-traverse": "^0.4.1",
     "keydown-from-click": "^1.1.1",
     "lodash": "^4.17.15",
+    "query-string": "^6.13.8",
     "ramda": "^0.25.0",
     "react-dropzone": "^10.1.3",
     "react-jsonschema-form": "^1.0.1",

--- a/react/queries/DeleteRedirect.graphql
+++ b/react/queries/DeleteRedirect.graphql
@@ -1,6 +1,6 @@
-mutation DeleteRedirect($path: String!) {
+mutation DeleteRedirect($path: String!, $binding: String!) {
   redirect @context(provider: "vtex.rewriter") {
-    delete(path: $path) {
+    delete(path: $path, locator: { from: $path, binding: $binding }) {
       endDate
       from
       to

--- a/react/queries/Redirect.graphql
+++ b/react/queries/Redirect.graphql
@@ -1,6 +1,7 @@
 query Redirect($path: String!) {
   redirect @context(provider: "vtex.rewriter") {
     get(path: $path) {
+      binding
       endDate
       from
       to

--- a/react/queries/Redirect.graphql
+++ b/react/queries/Redirect.graphql
@@ -1,6 +1,6 @@
-query Redirect($path: String!) {
+query Redirect($path: String!, $binding: String!) {
   redirect @context(provider: "vtex.rewriter") {
-    get(path: $path) {
+    get(path: $path, locator: { from: $path, binding: $binding }) {
       binding
       endDate
       from

--- a/react/queries/Redirects.graphql
+++ b/react/queries/Redirects.graphql
@@ -2,6 +2,7 @@ query Redirects($limit: Int, $next: String) {
   redirect @context(provider: "vtex.rewriter") {
     listRedirects(limit: $limit, next: $next) {
       routes {
+        binding
         endDate
         from
         to

--- a/react/queries/SaveRedirect.graphql
+++ b/react/queries/SaveRedirect.graphql
@@ -3,9 +3,10 @@ mutation saveRedirect(
   $from: String!
   $to: String!
   $type: RedirectTypes!
+  $binding: String
 ) {
   redirect @context(provider: "vtex.rewriter") {
-    save(route: { endDate: $endDate, from: $from, to: $to, type: $type }) {
+    save(route: { endDate: $endDate, from: $from, to: $to, type: $type, binding: $binding}) {
       endDate
       from
       to

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -282,6 +282,7 @@ declare global {
     from: string
     to: string
     type: RedirectTypes
+    binding: string
   }
 
   interface HighlightableIFrame extends HTMLIFrameElement {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6422,6 +6422,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.13.8:
+  version "6.13.8"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.8.tgz#8cf231759c85484da3cf05a851810d8e825c1159"
+  integrity sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
@@ -7287,6 +7296,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -7341,6 +7355,11 @@ streamsaver@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/streamsaver/-/streamsaver-2.0.3.tgz#9a3a46deb9dc59ed876a82d3116f5fd89182c537"
   integrity sha512-IpXeZ67YxcsrfZHe3yg/IyZ5KPfRSn1teDy5mRX2e8M6K410NcJNcR+SFQ2Z92DO36VBUArQP4Vy3Qu33MwIOQ==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
#### What problem is this solving?

Currently managing redirects in multi-language stores is hard, since it can only be done via APIs. This PR solves that by improving the Redirects UI in the admin to vary by binding.

#### How should this be manually tested?

[Workspace](https://redirectsui--muji.myvtex.com/admin/cms/redirects/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
<img width="1012" alt="Screen Shot 2021-01-27 at 11 45 06 AM" src="https://user-images.githubusercontent.com/12701600/106007521-26116580-6095-11eb-8696-a976475a8a93.png">
<img width="1004" alt="Screen Shot 2021-01-27 at 11 45 14 AM" src="https://user-images.githubusercontent.com/12701600/106007531-290c5600-6095-11eb-892b-a41fdd51ac57.png">

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
