### PR TITLE
fix: adding description and keywords with the same disabled behavior …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Setting `Description` and `Keywords` as editable fields with the same condition as `Title` in `admin-pages`
+
 ## [4.34.0] - 2021-01-22
 
 ### Added

--- a/react/components/admin/pages/Form/Form.tsx
+++ b/react/components/admin/pages/Form/Form.tsx
@@ -196,7 +196,7 @@ const Form: React.FunctionComponent<Props> = ({
         <>
           <FormFieldSeparator />
           <Textarea
-            disabled={!isInfoEditable}
+            disabled={!!data.context}
             label={intl.formatMessage(messages.seoDescription)}
             onChange={detailChangeHandlerGetter('metaTagDescription')}
             resize="vertical"
@@ -205,7 +205,7 @@ const Form: React.FunctionComponent<Props> = ({
           <FormFieldSeparator />
           <Select
             creatable
-            disabled={!isInfoEditable}
+            disabled={!!data.context}
             formatCreateLabel={(keyword: string) =>
               intl.formatMessage(messages.createKeywordsMessage, { keyword })
             }

--- a/react/components/admin/pages/Form/index.tsx
+++ b/react/components/admin/pages/Form/index.tsx
@@ -293,7 +293,17 @@ class FormContainer extends Component<Props, State> {
             path: this.state.data.path,
             routeId: this.state.data.routeId,
             uuid: this.state.data.uuid,
+            metaTagKeywords: this.state.data.metaTagKeywords,
+            metaTagDescription: this.state.data.metaTagDescription,
           }
+
+      const metaTags =
+        metaTagDescription || metaTagKeywords
+          ? {
+              description: metaTagDescription,
+              keywords: metaTagKeywords?.map(({ value }) => value),
+            }
+          : undefined
 
       this.setState({ isLoading: true }, async () => {
         try {
@@ -307,15 +317,7 @@ class FormContainer extends Component<Props, State> {
                 declarer,
                 domain,
                 interfaceId,
-                metaTags:
-                  metaTagDescription || metaTagKeywords
-                    ? {
-                        description: metaTagDescription,
-                        keywords: (metaTagKeywords || []).map(
-                          ({ value }) => value
-                        ),
-                      }
-                    : undefined,
+                metaTags,
                 pages:
                   pages &&
                   pages.map(page => {


### PR DESCRIPTION
#### What problem is this solving?

A lot of people is asking about: "why some fields could not be editable when a user create the route in route.json's file?"

So, given that motivation, I made this change to maintain the same rule for editing the SEO fields, according to the title field

#### How should this be manually tested?

Go to the workspace and try to edit the fields (this route was created in routes.json file)
[Workspace](https://iespinoza--tokstokio.myvtex.com/admin/cms/pages/store.custom/)

Check in master, and you gonna see this fields as disabled
[Workspace](https://master--tokstokio.myvtex.com/admin/cms/pages/store.custom/)

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/P3gCL7t3cbOWUN8ma7/giphy.gif)
