### PR TITLE
feat: add name on menu items created on CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Adding submenu id as title name on `ArrayFieldTemplateItem` when created on site editor
 
 ## [4.37.0] - 2021-02-09
 - Adds support for multi binding for redirect CSV managment

--- a/react/components/form/ArrayFieldTemplate/ArrayFieldTemplateItem/index.tsx
+++ b/react/components/form/ArrayFieldTemplate/ArrayFieldTemplateItem/index.tsx
@@ -168,7 +168,9 @@ const ArrayFieldTemplateItem: React.FC<Props> = props => {
 
   const title =
     children.props.formData.__editorItemTitle ||
-    path(['items', 'properties', '__editorItemTitle', 'default'], schema)
+    path(['items', 'properties', '__editorItemTitle', 'default'], schema) ||
+    (children.props.formData.type === 'custom' &&
+      children.props.formData.iconId)
 
   return (
     <div


### PR DESCRIPTION
#### What problem is this solving?

Strange behavior that every items created on CMS menu have the same name as "Item", is legit to have the item id as name on every menu item created

#### How should this be manually tested?

Go to Site Editor, click on submenu in apparel and accessories, inspect, see the results and try to add a new one

[Workspace](https://iespinoza--storecomponents.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage

​​Before
![image](https://user-images.githubusercontent.com/13649073/108129227-a58ac700-708c-11eb-8f46-550befa06e73.png)


After 
![image](https://user-images.githubusercontent.com/13649073/108127455-05cc3980-708a-11eb-855d-d1a145e8db28.png)



#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |


#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/lD9C5bKJk4ycg/giphy.gif)
