### PR TITLE
Fixes querystring problem

### DIFF
--- a/react/RedirectForm.tsx
+++ b/react/RedirectForm.tsx
@@ -25,6 +25,7 @@ import Loader from './components/Loader'
 import Redirect from './queries/Redirect.graphql'
 import TenantInfoQuery from './queries/TenantInfo.graphql'
 import { getStoreBindings } from './utils/bindings'
+import { parseRedirectQueryString } from './components/admin/redirects/utils'
 
 interface CustomProps {
   params: {
@@ -94,14 +95,14 @@ class RedirectForm extends Component<Props, State> {
     if (!formData) {
       try {
         const rawQuerystring = history?.location?.search ?? ''
-        const querystring = queryString.parse(rawQuerystring)
-        const { binding, ...rest } = querystring
-        const restQuerystring = queryString.stringify(rest)
+        const { binding, q } = queryString.parse(rawQuerystring)
+        const restQueryString =
+          typeof q === 'string' && parseRedirectQueryString(q)
         const response = await client.query<RedirectQuery>({
           query: Redirect,
           variables: {
             path: `/${params.path}${
-              restQuerystring ? '?' + restQuerystring : ''
+              restQueryString ? '?' + restQueryString : ''
             }`,
             binding: binding,
           },

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -11,6 +11,7 @@ import { Binding } from 'vtex.tenant-graphql'
 
 import { getFormattedLocalizedDate } from '../../../../utils/date'
 import { BASE_URL, NEW_REDIRECT_ID } from '../consts'
+import { slugifyRedirectQueryString } from '../utils'
 import CreateButton from './CreateButton'
 import { messages } from './messages'
 
@@ -130,11 +131,17 @@ const List: React.FC<Props> = ({
   const handleItemView = useCallback(
     (event: { rowData: Redirect }) => {
       const selectedItem = event.rowData
-      const bindingQS = selectedItem.from.includes('?')
+      const hasQueryString = selectedItem.from.includes('?')
+      const bindingQueryString = hasQueryString
         ? `&binding=${selectedItem.binding}`
         : `?binding=${selectedItem.binding}`
+      const [itemFrom, itemQueryString] = hasQueryString
+        ? selectedItem.from.split('?')
+        : [selectedItem.from, '']
+      const parsedQueryString =
+        itemQueryString && `?q=${slugifyRedirectQueryString(itemQueryString)}`
       navigate({
-        to: `${BASE_URL}${selectedItem.from}${bindingQS}`,
+        to: `${BASE_URL}${itemFrom}${parsedQueryString}${bindingQueryString}`,
       })
     },
     [navigate]

--- a/react/components/admin/redirects/utils.ts
+++ b/react/components/admin/redirects/utils.ts
@@ -1,0 +1,5 @@
+export const slugifyRedirectQueryString = (data: string) =>
+  data.replace(/=/g, '/').replace(/&/g, ';')
+
+export const parseRedirectQueryString = (data: string) =>
+  data.replace(/\//g, '=').replace(/;/g, '&')


### PR DESCRIPTION
#### What problem is this solving?
Currently the Redirects UI adds the redirect querystring to the URL, but the `navigate` function changes the order of the querystring parameters, making the form redirect query to return null instead of the correct redirect. 

This PR creates a solution to keep the redirect querystring in the same order for the query to be correct.

#### How should this be manually tested?
You can enter `muji`'s redirect admin and click on the first redirect, in master the form is not shown but in the following workspace it should:

[Workspace](https://fox--muji.myvtex.com/admin/cms/redirects/pages/online.asp/?binding=2afad550-25cd-45f0-8b92-78d421691690&q=Sec/18;Sub/75;PID/12488;qclr/4550182715880)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️   | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
