### PR TITLE
Fix/locale selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Block selector not working after a locale change
+- Block selector not working after a locale change.
 
 ### Added
-- Block selector status(wait)
+- Block selector status(wait).
 
 ### Changed
 - Hides query strings from site editor top bar.
@@ -22,14 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - File format disclaimer to both iOS and Android icons uploaded via the PWA section inside of Store settings page not added in some languages.
 
 ## [4.39.0] - 2021-04-05
-
 ### Added
-
 - File format disclaimer to both iOS and Android icons uploaded via the PWA section inside of Store settings page.
-
-## [4.37.0] - 2021-02-09
-
-- Adds support for multi binding for redirect CSV managment
 
 ## [4.38.1] - 2021-03-17
 
@@ -37,8 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - I18n En, Es, Pt, Ro and Jp.
 - Context.json with new strings.
-
 ## [4.38.0] - 2021-03-08
+
 
 ### Added
 
@@ -47,29 +41,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - I18n Ro.
-
 ## [4.37.0] - 2021-02-09
-
 ### Added
-
 - Support for multi binding for redirect CSV management.
 
 ## [4.36.1] - 2021-02-08
-
 ### Fixed
-
 - Preventing unchanged information to be sent and updated as undefined in `admin-pages\Form\index`
 
 ## [4.36.0] - 2021-02-02
-
 ### Fixed
-
 - Setting `Description` and `Keywords` as editable fields with the same condition as `Title` in `admin-pages`
 
 ## [4.35.0] - 2021-02-02
-
 ### Added
-
 - Adds binding selector for CMS Redirects
 
 ## [4.34.0] - 2021-01-22
@@ -85,15 +70,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Site editor flag in the iframe URL.
 
 ## [4.32.0] - 2021-01-21
-
 ### Added
-
-- Adds binding selector for CMS Pages
+- Adds binding selector for CMS Pages 
 
 ## [4.31.1] - 2021-01-20
-
 ### Fixed
-
 - Sending blockId in `Form index` component even when is not changed to prevent unexpected behaviors
 
 ## [4.31.0] - 2021-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Block selector not working after a locale change
+
+### Added
+- Block selector status(wait)
+
+### Changed
+- Hides query strings from site editor top bar.
+
 ## [4.40.0] - 2021-04-13
 
 ### Fixed
 - File format disclaimer to both iOS and Android icons uploaded via the PWA section inside of Store settings page not added in some languages.
 
 ## [4.39.0] - 2021-04-05
+
 ### Added
+
 - File format disclaimer to both iOS and Android icons uploaded via the PWA section inside of Store settings page.
+
+## [4.37.0] - 2021-02-09
+
+- Adds support for multi binding for redirect CSV managment
 
 ## [4.38.1] - 2021-03-17
 
@@ -22,8 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - I18n En, Es, Pt, Ro and Jp.
 - Context.json with new strings.
-## [4.38.0] - 2021-03-08
 
+## [4.38.0] - 2021-03-08
 
 ### Added
 
@@ -32,20 +47,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - I18n Ro.
+
 ## [4.37.0] - 2021-02-09
+
 ### Added
+
 - Support for multi binding for redirect CSV management.
 
 ## [4.36.1] - 2021-02-08
+
 ### Fixed
+
 - Preventing unchanged information to be sent and updated as undefined in `admin-pages\Form\index`
 
 ## [4.36.0] - 2021-02-02
+
 ### Fixed
+
 - Setting `Description` and `Keywords` as editable fields with the same condition as `Title` in `admin-pages`
 
 ## [4.35.0] - 2021-02-02
+
 ### Added
+
 - Adds binding selector for CMS Redirects
 
 ## [4.34.0] - 2021-01-22
@@ -61,11 +85,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Site editor flag in the iframe URL.
 
 ## [4.32.0] - 2021-01-21
+
 ### Added
-- Adds binding selector for CMS Pages 
+
+- Adds binding selector for CMS Pages
 
 ## [4.31.1] - 2021-01-20
+
 ### Fixed
+
 - Sending blockId in `Form index` component even when is not changed to prevent unexpected behaviors
 
 ## [4.31.0] - 2021-01-13

--- a/manifest.json
+++ b/manifest.json
@@ -26,9 +26,7 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish -r vtex --verbose"

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -32,10 +32,6 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
 
   let src = path ? `/${path}` : '/'
 
-  // if (window?.location.search && !src.includes(window.location.search)) {
-  //   src = src + `${window.location.search}`
-  // }
-
   if (binding && !src.includes('__bindingAddress')) {
     src += `${getJoiner(src)}__bindingAddress=${binding.canonicalBaseAddress}`
   }

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -32,9 +32,9 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
 
   let src = path ? `/${path}` : '/'
 
-  if (window?.location.search && !src.includes(window.location.search)) {
-    src = src + `${window.location.search}`
-  }
+  // if (window?.location.search && !src.includes(window.location.search)) {
+  //   src = src + `${window.location.search}`
+  // }
 
   if (binding && !src.includes('__bindingAddress')) {
     src += `${getJoiner(src)}__bindingAddress=${binding.canonicalBaseAddress}`

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -32,11 +32,18 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
 
   let src = path ? `/${path}` : '/'
 
+  if (window?.location.search && !src.includes(window.location.search)) {
+    src = src + `${window.location.search}`
+  }
+
   if (binding && !src.includes('__bindingAddress')) {
+    console.log('PASSOU')
     src += `${getJoiner(src)}__bindingAddress=${binding.canonicalBaseAddress}`
   }
 
-  src += `${getJoiner(src)}__siteEditor`
+  if (!src.includes('__siteEditor')) {
+    src += `${getJoiner(src)}__siteEditor=true`
+  }
 
   return (
     <iframe

--- a/react/components/EditorContainer/StoreIframe.tsx
+++ b/react/components/EditorContainer/StoreIframe.tsx
@@ -37,7 +37,6 @@ const StoreIframe: React.FunctionComponent<Props> = ({ path }) => {
   }
 
   if (binding && !src.includes('__bindingAddress')) {
-    console.log('PASSOU')
     src += `${getJoiner(src)}__bindingAddress=${binding.canonicalBaseAddress}`
   }
 

--- a/react/components/EditorContainer/Topbar/BlockPicker.tsx
+++ b/react/components/EditorContainer/Topbar/BlockPicker.tsx
@@ -4,7 +4,6 @@ import { InjectedIntlProps, injectIntl } from 'react-intl'
 import { Tooltip } from 'vtex.styleguide'
 
 import { useEditorContext } from '../../EditorContext'
-
 import { useHover } from './hooks'
 import IconPicker from './icons/IconPicker'
 
@@ -26,13 +25,17 @@ const BlockPicker: React.FC<InjectedIntlProps> = ({ intl }) => {
       position="bottom"
     >
       <button
+        style={editor.mode === 'disabled' ? { cursor: 'wait' } : {}}
         className={`w2 h2 bg-white br2 b--transparent outline-0 pointer flex justify-center items-center ${
-          editor.editMode || hover ? 'c-action-primary' : 'c-on-disabled'
+          editor.editMode || (hover && editor.mode !== 'disabled')
+            ? 'c-action-primary'
+            : 'c-on-disabled'
         }`}
         onClick={handleEditModeToggle}
         onKeyPress={handleKeyPress}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        disabled={editor.mode === 'disabled'}
       >
         <IconPicker />
       </button>

--- a/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
+++ b/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
@@ -20,13 +20,27 @@ const LocaleSelector: React.FC<Props> = ({
 }) => {
   const { culture, emitter } = iframeRuntime
 
+  const editor = useEditorContext()
+
   const [locale, setLocale] = React.useState(culture.locale)
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       setLocale(e.target.value)
 
-      emitter.emit('localesChanged', e.target.value)
+      emitter.emit('localesChanged', e.target.value, null, () => {
+        if (editor.iframeWindow) {
+          const searchParams = new URLSearchParams(
+            editor.iframeWindow.location.search
+          )
+
+          const bindingQueryString = searchParams.get('__bindingAddress')
+
+          editor.iframeWindow.location.search = `__bindingAddress=${bindingQueryString}&__localeAddress=${e.target.value}&__siteEditor=true`
+        }
+      })
+
+      editor.setMode('disabled')
     },
     [emitter]
   )
@@ -35,6 +49,8 @@ const LocaleSelector: React.FC<Props> = ({
     if (locale !== culture.locale) {
       setLocale(culture.locale)
     }
+
+    if (editor.mode !== 'layout') editor.setMode('layout')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [culture.locale])
 
@@ -53,7 +69,6 @@ const LocaleSelector: React.FC<Props> = ({
     [className, handleChange, isDisabled, locale, options]
   )
 
-  const editor = useEditorContext()
   const intl = useIntl()
 
   return editor.editTreePath ? (

--- a/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
+++ b/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
@@ -26,21 +26,38 @@ const LocaleSelector: React.FC<Props> = ({
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      setLocale(e.target.value)
-
-      emitter.emit('localesChanged', e.target.value, null, () => {
-        if (editor.iframeWindow) {
-          const searchParams = new URLSearchParams(
-            editor.iframeWindow.location.search
-          )
-
-          const bindingQueryString = searchParams.get('__bindingAddress')
-
-          editor.iframeWindow.location.search = `__bindingAddress=${bindingQueryString}&__localeAddress=${e.target.value}&__siteEditor=true`
-        }
-      })
-
       editor.setMode('disabled')
+
+      setLocale(e?.target?.value)
+
+      emitter.emit(
+        'localesChanged',
+        e?.target?.value,
+        null,
+        (locale: string) => {
+          let bindingQueryString
+
+          if (editor.iframeWindow) {
+            const searchParams = new URLSearchParams(
+              editor?.iframeWindow?.location.search
+            )
+
+            const bindingAddress = searchParams.get('__bindingAddress')
+
+            if (bindingAddress) {
+              bindingQueryString = `__bindingAddress=${decodeURIComponent(
+                bindingAddress
+              )}`
+            }
+
+            if (e?.target?.value) {
+              editor.iframeWindow.location.search = `${bindingQueryString}&__locale=${e.target.value}&__siteEditor=true`
+            } else {
+              editor.iframeWindow.location.search = `${bindingQueryString}&__locale=${locale}&__siteEditor=true`
+            }
+          }
+        }
+      )
     },
     [emitter]
   )

--- a/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
+++ b/react/components/EditorContainer/Topbar/ContextSelectors/LocaleSelector.tsx
@@ -66,10 +66,14 @@ const LocaleSelector: React.FC<Props> = ({
     if (locale !== culture.locale) {
       setLocale(culture.locale)
     }
-
-    if (editor.mode !== 'layout') editor.setMode('layout')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [culture.locale])
+
+  React.useEffect(() => {
+    if (editor.mode !== 'content') {
+      editor.setMode('content')
+    }
+  }, [culture.locale, culture.country])
 
   const Selector = React.useCallback(
     () => (

--- a/react/components/EditorContainer/Topbar/ContextSelectors/index.tsx
+++ b/react/components/EditorContainer/Topbar/ContextSelectors/index.tsx
@@ -96,7 +96,7 @@ const ContextSelectors: React.FC<WithApolloClient<Props>> = ({
         if (newBinding && editor.iframeWindow) {
           setBinding(newBinding)
 
-          editor.iframeWindow.location.search = `__bindingAddress=${newBinding.canonicalBaseAddress}&__siteEditor`
+          editor.iframeWindow.location.search = `__bindingAddress=${newBinding.canonicalBaseAddress}&__siteEditor=true`
         }
       }
     },

--- a/react/components/EditorContainer/Topbar/ContextSelectors/index.tsx
+++ b/react/components/EditorContainer/Topbar/ContextSelectors/index.tsx
@@ -98,6 +98,8 @@ const ContextSelectors: React.FC<WithApolloClient<Props>> = ({
 
           editor.iframeWindow.location.search = `__bindingAddress=${newBinding.canonicalBaseAddress}&__siteEditor=true`
         }
+
+        editor.setMode('disabled')
       }
     },
     [bindings, setBinding, editor.iframeWindow]

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -38,8 +38,6 @@ const UrlInput = () => {
 
   React.useEffect(() => {
     setUrl(urlPath)
-
-    if (editor.mode !== 'layout') editor.setMode('layout')
   }, [urlPath])
 
   const onEnter = (

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -10,9 +10,9 @@ const UrlInput = () => {
 
   const resolveUrlPath = (pathname: string, searchQueries: string) => {
     const searchParams = new URLSearchParams(searchQueries)
-    const SEARCH_QUERIES_BLACKLIST = ['__siteEditor', '__bindingAddress']
+    const SEARCH_QUERIES_TO_HIDE = ['__siteEditor', '__bindingAddress']
 
-    SEARCH_QUERIES_BLACKLIST.forEach(query => {
+    SEARCH_QUERIES_TO_HIDE.forEach(query => {
       searchParams.delete(query)
     })
 

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -10,9 +10,9 @@ const UrlInput = () => {
 
   const resolveUrlPath = (pathname: string, searchQueries: string) => {
     const searchParams = new URLSearchParams(searchQueries)
-    const blacklistedSearchQueries = ['__siteEditor', '__bindingAddress']
+    const SEARCH_QUERIES_BLACKLIST = ['__siteEditor', '__bindingAddress']
 
-    blacklistedSearchQueries.forEach(query => {
+    SEARCH_QUERIES_BLACKLIST.forEach(query => {
       searchParams.delete(query)
     })
 

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -8,9 +8,26 @@ const UrlInput = () => {
 
   const editor = useEditorContext()
 
+  const resolveUrlPath = (pathname: string, searchQueries: string) => {
+    const searchParams = new URLSearchParams(searchQueries)
+    const blacklistedSearchQueries = ['__siteEditor', '__bindingAddress']
+
+    blacklistedSearchQueries.forEach(query => {
+      searchParams.delete(query)
+    })
+
+    if (searchParams.toString().length) {
+      return pathname + `?${searchParams.toString()}`
+    }
+
+    return pathname
+  }
+
   const urlPath = editor.iframeWindow
-    ? editor.iframeWindow.location.pathname +
-      editor.iframeWindow.location.search
+    ? resolveUrlPath(
+        editor.iframeWindow.location.pathname,
+        editor.iframeWindow.location.search
+      )
     : ''
 
   const [url, setUrl] = React.useState(urlPath)

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -13,7 +13,7 @@ const UrlInput = () => {
     const SEARCH_QUERIES_TO_HIDE = [
       '__siteEditor',
       '__bindingAddress',
-      '__localeAddress',
+      '__locale',
     ]
 
     SEARCH_QUERIES_TO_HIDE.forEach(query => {
@@ -21,7 +21,7 @@ const UrlInput = () => {
     })
 
     if (searchParams.toString().length) {
-      return pathname + `?${searchParams.toString()}`
+      return pathname + decodeURIComponent(`?${searchParams.toString()}`)
     }
 
     return pathname

--- a/react/components/EditorContainer/Topbar/UrlInput.tsx
+++ b/react/components/EditorContainer/Topbar/UrlInput.tsx
@@ -10,7 +10,11 @@ const UrlInput = () => {
 
   const resolveUrlPath = (pathname: string, searchQueries: string) => {
     const searchParams = new URLSearchParams(searchQueries)
-    const SEARCH_QUERIES_TO_HIDE = ['__siteEditor', '__bindingAddress']
+    const SEARCH_QUERIES_TO_HIDE = [
+      '__siteEditor',
+      '__bindingAddress',
+      '__localeAddress',
+    ]
 
     SEARCH_QUERIES_TO_HIDE.forEach(query => {
       searchParams.delete(query)
@@ -34,6 +38,8 @@ const UrlInput = () => {
 
   React.useEffect(() => {
     setUrl(urlPath)
+
+    if (editor.mode !== 'layout') editor.setMode('layout')
   }, [urlPath])
 
   const onEnter = (

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -306,7 +306,7 @@ class EditorProvider extends Component<Props, State> {
   }
 
   public handleSetMode = (mode: EditorMode) => {
-    this.setState({ mode })
+    this.setState({ mode, editMode: mode === 'content' ? true : false })
   }
 
   public handleChangeIframeUrl = (url: string) => {

--- a/react/components/EditorProvider.tsx
+++ b/react/components/EditorProvider.tsx
@@ -306,7 +306,7 @@ class EditorProvider extends Component<Props, State> {
   }
 
   public handleSetMode = (mode: EditorMode) => {
-    this.setState({ mode, editMode: mode === 'content' ? true : false })
+    this.setState({ mode, editMode: mode === 'content' ? false : true })
   }
 
   public handleChangeIframeUrl = (url: string) => {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -170,7 +170,7 @@ declare global {
 
   type ConfigurationDevice = 'any' | 'desktop' | 'mobile'
 
-  type EditorMode = 'content' | 'layout'
+  type EditorMode = 'content' | 'layout' | 'disabled'
 
   interface EditorConditionSection {
     activeConditions: string[]


### PR DESCRIPTION
#### What problem is this solving?

The context for this change is in the [#prod-muji-eu](https://vtex.slack.com/archives/C01619D8146/p1614177871014400) channel.

1. On a binding selector change, the block selector not works without toggling it.
2. On a locale selector change, the block selector not works until the page is reloaded.

#### How should this be manually tested?

https://www.loom.com/share/0ea28c9573754baeb8d7d96e3ded5156

https://vitorflg--muji.myvtex.com/admin/cms/site-editor

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

It already adds the changes of this PR(Hide query string from the iframe top bar): https://github.com/vtex-apps/admin-pages/pull/368