### PR TITLE
NAD-530 - Add temporary newadmin warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Temporary warning banner for the newadmin workspaces to let clients know that the module only affects the production store on the master environment.
+- Temporary warning banner for the `newadmin` workspaces to let clients know that the module only affects the production store on the master environment.
 
 ## [4.42.0] - 2021-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Temporary warning banner for the newadmin workspaces to let clients know that the module only works on the master environment.
+- Temporary warning banner for the newadmin workspaces to let clients know that the module only affects the production store on the master environment.
 
 ## [4.42.0] - 2021-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Temporary warning banner for the newadmin workspaces to let clients know that the module only works on the master environment.
+
 ## [4.42.0] - 2021-05-13
 
 ### Changed
+
 - Add messages for "B2B behavior enabled".
 - Change BaseInput to render "read-only" schema fields.
 
 ## [4.41.0] - 2021-05-03
 
 ### Added
+
 - I18n Fr, It, Kr and Nl.
 
 ### Changed
+
 - Crowdin configuration file.
 
 ## [4.40.2] - 2021-04-28

--- a/messages/context.json
+++ b/messages/context.json
@@ -553,5 +553,5 @@
   "admin/store.advancedSettings.enableLazyFold.title": "admin/store.advancedSettings.enableLazyFold.title",
   "admin/store.advancedSettings.enableLazyFold.description": "admin/store.advancedSettings.enableLazyFold.description",
   "admin/pages.editor.newadmin.alert": "admin/pages.editor.newadmin.alert",
-  "admin/pages.editor.newadmin.alert.button": "admin/pages.editor.newadmin.alert.button"
+  "admin/pages.editor.newadmin.alert.anchor": "admin/pages.editor.newadmin.alert.anchor"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "admin/store.advancedSettings.enableLazyFooter.title",
   "admin/store.advancedSettings.enableLazyFooter.description": "admin/store.advancedSettings.enableLazyFooter.description",
   "admin/store.advancedSettings.enableLazyFold.title": "admin/store.advancedSettings.enableLazyFold.title",
-  "admin/store.advancedSettings.enableLazyFold.description": "admin/store.advancedSettings.enableLazyFold.description"
+  "admin/store.advancedSettings.enableLazyFold.description": "admin/store.advancedSettings.enableLazyFold.description",
+  "admin/pages.editor.newadmin.alert": "admin/pages.editor.newadmin.alert",
+  "admin/pages.editor.newadmin.alert.button": "admin/pages.editor.newadmin.alert.button"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Enable lazy rendering of the page footer",
   "admin/store.advancedSettings.enableLazyFooter.description": "Lazily render the page footer and lazily loads its assets, which helps improving the performance of the first render of the page.",
   "admin/store.advancedSettings.enableLazyFold.title": "Enable lazy loading of assets below-the-fold",
-  "admin/store.advancedSettings.enableLazyFold.description": "Enables lazy loading of the JS files of the components below the `__fold__` block."
+  "admin/store.advancedSettings.enableLazyFold.description": "Enables lazy loading of the JS files of the components below the `__fold__` block.",
+  "admin/pages.editor.newadmin.alert": "Site Editor funciona como un ambiente de prueba en la versión beta del Admin VTEX. Para que los cambios se apliquen en su tienda online, acceda a la versión anterior del Admin.",
+  "admin/pages.editor.newadmin.alert.button": "Ir a versión anterior de Site Editor"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Lazily render the page footer and lazily loads its assets, which helps improving the performance of the first render of the page.",
   "admin/store.advancedSettings.enableLazyFold.title": "Enable lazy loading of assets below-the-fold",
   "admin/store.advancedSettings.enableLazyFold.description": "Enables lazy loading of the JS files of the components below the `__fold__` block.",
-  "admin/pages.editor.newadmin.alert": "Site Editor funciona como un ambiente de prueba en la versión beta del Admin VTEX. Para que los cambios se apliquen en su tienda online, acceda a la versión anterior del Admin.",
-  "admin/pages.editor.newadmin.alert.button": "Ir a versión anterior de Site Editor"
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Representa el pie de página y carga los recursos de forma Lazy, lo que ayuda a mejorar el rendimiento de la primera representación de la página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar la carga Lazy de recursos en el bloque inferior",
   "admin/store.advancedSettings.enableLazyFold.description": "Permite la carga diferida de los archivos JS de los componentes (above the fold)",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, please use the previous Admin environment.",
-  "admin/pages.editor.newadmin.alert.button": "Go to previous Site Editor"
+  "admin/pages.editor.newadmin.alert": "Site Editor funciona como un ambiente de prueba en la versión beta del Admin VTEX. Para que los cambios se apliquen en su tienda online, ",
+  "admin/pages.editor.newadmin.alert.anchor": "acceda a la versión anterior del Admin."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Activar la representación Lazy del pie de página",
   "admin/store.advancedSettings.enableLazyFooter.description": "Representa el pie de página y carga los recursos de forma Lazy, lo que ayuda a mejorar el rendimiento de la primera representación de la página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar la carga Lazy de recursos en el bloque inferior",
-  "admin/store.advancedSettings.enableLazyFold.description": "Permite la carga diferida de los archivos JS de los componentes (above the fold)"
+  "admin/store.advancedSettings.enableLazyFold.description": "Permite la carga diferida de los archivos JS de los componentes (above the fold)",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, please use the previous Admin environment.",
+  "admin/pages.editor.newadmin.alert.button": "Go to previous Site Editor"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Activer le rendu différé du pied de page",
   "admin/store.advancedSettings.enableLazyFooter.description": "Rendu différé du pied de page et chargement différé de ses actifs, permettant d'améliorer les performances du premier rendu de la page.",
   "admin/store.advancedSettings.enableLazyFold.title": "Activez le chargement différé des ressources sous la ligne de flottaison (fold)",
-  "admin/store.advancedSettings.enableLazyFold.description": "Permet le chargement différé des fichiers JS des composants situés sous le bloc `__fold__`."
+  "admin/store.advancedSettings.enableLazyFold.description": "Permet le chargement différé des fichiers JS des composants situés sous le bloc `__fold__`.",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Abilita il rendering differito del piè di pagina",
   "admin/store.advancedSettings.enableLazyFooter.description": "Esegui il rendering differito del piè di pagina ed esegui il caricamento differito delle rispettive attività. Ciò migliora le prestazioni del primo rendering della pagina.",
   "admin/store.advancedSettings.enableLazyFold.title": "Abilita il caricamento differito delle risorse \"Below the Fold\"",
-  "admin/store.advancedSettings.enableLazyFold.description": "Abilita il caricamento differito del file JS dei componenti del blocco \"Below the __fold__\"."
+  "admin/store.advancedSettings.enableLazyFold.description": "Abilita il caricamento differito del file JS dei componenti del blocco \"Below the __fold__\".",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title":"ページフッターの遅延レンダリングを有効にする",
   "admin/store.advancedSettings.enableLazyFooter.description":"ページフッターのレンダリングやそのアセットの読み込みを遅延させます。こうするとページの最初のレンダリングのパフォーマンスが改善されます。",
   "admin/store.advancedSettings.enableLazyFold.title":"ファーストビュー領域以外のアセットの遅延読み込みを有効にする",
-  "admin/store.advancedSettings.enableLazyFold.description":"`__fold__` ブロックより下にあるコンポーネントの JS ファイルの遅延読み込みを有効にします。"
+  "admin/store.advancedSettings.enableLazyFold.description":"`__fold__` ブロックより下にあるコンポーネントの JS ファイルの遅延読み込みを有効にします。",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "페이지 푸터의 지연 렌더링 사용",
   "admin/store.advancedSettings.enableLazyFooter.description": "페이지 푸터를 지연 렌더링하고 자산을 지연 로드하여, 페이지의 첫 번째 렌더링 성능을 개선하는 데 도움이 됩니다.",
   "admin/store.advancedSettings.enableLazyFold.title": "폴더 아래쪽 자산의 지연 로드 사용",
-  "admin/store.advancedSettings.enableLazyFold.description": "'__fold__' 블록 아래에 있는 구성 요소의 JS 파일을 지연 로드할 수 있습니다."
+  "admin/store.advancedSettings.enableLazyFold.description": "'__fold__' 블록 아래에 있는 구성 요소의 JS 파일을 지연 로드할 수 있습니다.",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Trage rendering van de paginavoetregel inschakelen",
   "admin/store.advancedSettings.enableLazyFooter.description": "Render de voettekst van de pagina op een trage manier en laadt de assets op een trage manier, wat de prestaties van de eerste render van de pagina ten goede komt.",
   "admin/store.advancedSettings.enableLazyFold.title": "Schakel traag laden van activa onder de vouw in",
-  "admin/store.advancedSettings.enableLazyFold.description": "Schakel het traag laden in van de JS bestanden van de componenten onder het `__fold__` blok in."
+  "admin/store.advancedSettings.enableLazyFold.description": "Schakel het traag laden in van de JS bestanden van de componenten onder het `__fold__` blok in.",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Ativar renderização Lazy do rodapé da página",
   "admin/store.advancedSettings.enableLazyFooter.description": "Renderiza de forma Lazy o rodapé da página e o carregamento de seus ativos, o que ajuda a melhorar o desempenho da primeira renderização da página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar o carregamento de forma Lazy de ativos abaixo da dobra",
-  "admin/store.advancedSettings.enableLazyFold.description": "Permite o carregamento de forma Lazy dos arquivos JS dos componentes (above the fold)"
+  "admin/store.advancedSettings.enableLazyFold.description": "Permite o carregamento de forma Lazy dos arquivos JS dos componentes (above the fold)",
+  "admin/pages.editor.newadmin.alert": "O Site Editor funciona como um ambiente teste nesta versão Beta do Admin da VTEX. Para aplicar mudanças na sua loja online, por favor acesse o ambiente do Admin anterior.",
+  "admin/pages.editor.newadmin.alert.button": "Ir para o Site Editor anterior"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Renderiza de forma Lazy o rodapé da página e o carregamento de seus ativos, o que ajuda a melhorar o desempenho da primeira renderização da página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar o carregamento de forma Lazy de ativos abaixo da dobra",
   "admin/store.advancedSettings.enableLazyFold.description": "Permite o carregamento de forma Lazy dos arquivos JS dos componentes (above the fold)",
-  "admin/pages.editor.newadmin.alert": "O Site Editor funciona como um ambiente teste nesta versão Beta do Admin da VTEX. Para aplicar mudanças na sua loja online, por favor acesse o ambiente do Admin anterior.",
-  "admin/pages.editor.newadmin.alert.button": "Ir para o Site Editor anterior"
+  "admin/pages.editor.newadmin.alert": "O Site Editor funciona como um ambiente teste nesta versão Beta do Admin da VTEX. Para aplicar mudanças na sua loja online, ",
+  "admin/pages.editor.newadmin.alert.anchor": "por favor acesse o ambiente do Admin anterior."
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -551,5 +551,7 @@
   "admin/store.advancedSettings.enableLazyFooter.title": "Activează redarea lentă a footer-ului paginii",
   "admin/store.advancedSettings.enableLazyFooter.description": "Redă în mod lent footer-ul paginii şi încarcă lent activele sale, ceea ce ajută la îmbunătăţirea performanţei la prima redare a paginii.",
   "admin/store.advancedSettings.enableLazyFold.title": "Activează încărcarea lentă a activelor de dedesubt.",
-  "admin/store.advancedSettings.enableLazyFold.description": "Activează încărcarea lentă a fişierelor JS a componentelor de sub elementul __fold__."
+  "admin/store.advancedSettings.enableLazyFold.description": "Activează încărcarea lentă a fişierelor JS a componentelor de sub elementul __fold__.",
+  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
 }

--- a/react/PageEditor.tsx
+++ b/react/PageEditor.tsx
@@ -3,6 +3,7 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import StoreIframe from './components/EditorContainer/StoreIframe'
 import EditorProvider from './components/EditorProvider'
+import { TemporaryAlert } from './components/TemporaryAlert'
 import { useAdminLoadingContext } from './utils/AdminLoadingContext'
 
 interface Props extends RenderContextProps {
@@ -44,6 +45,7 @@ const PageEditor: React.FC<Props> = props => {
 
   return (
     <div className="h-100 overflow-y-auto bg-light-silver">
+      <TemporaryAlert />
       <EditorProvider isSiteEditor={isSiteEditor}>
         <StoreIframe path={path} />
       </EditorProvider>

--- a/react/components/TemporaryAlert/index.tsx
+++ b/react/components/TemporaryAlert/index.tsx
@@ -14,10 +14,10 @@ import { useRuntime } from 'vtex.render-runtime'
 const system = createSystem('admin-pages')
 
 export function TemporaryAlert() {
-  const { workspace } = useRuntime()
+  const { workspace, production } = useRuntime()
   const { formatMessage } = useIntl()
 
-  if (workspace !== 'newadmin') {
+  if (workspace !== 'newadmin' || !production) {
     return null
   }
 

--- a/react/components/TemporaryAlert/index.tsx
+++ b/react/components/TemporaryAlert/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import {
+  Alert,
+  ThemeProvider,
+  createSystem,
+  Box,
+  Button,
+  Flex,
+  IconNotifications,
+} from '@vtex/admin-ui'
+import { useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
+
+const system = createSystem('admin-pages')
+
+export function TemporaryAlert() {
+  const { workspace } = useRuntime()
+  const { formatMessage } = useIntl()
+
+  if (workspace !== 'newadmin') {
+    return null
+  }
+
+  const handleOnClick = () => {
+    window.top.location.href = window.top.location.href.replace(
+      `${workspace}--`,
+      ''
+    )
+  }
+
+  return (
+    <ThemeProvider system={system}>
+      <Box
+        csx={{
+          padding: 4,
+        }}
+      >
+        <Alert visible fluid>
+          <Flex>
+            <Flex align="center">
+              <IconNotifications
+                csx={{
+                  color: 'blue',
+                }}
+              />
+            </Flex>
+            <Box
+              csx={{
+                marginX: 2,
+              }}
+            >
+              {formatMessage({ id: 'admin/pages.editor.newadmin.alert' })}
+            </Box>
+            <Button onClick={handleOnClick}>
+              {formatMessage({
+                id: 'admin/pages.editor.newadmin.alert.button',
+              })}
+            </Button>
+          </Flex>
+        </Alert>
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/react/components/TemporaryAlert/index.tsx
+++ b/react/components/TemporaryAlert/index.tsx
@@ -44,13 +44,14 @@ export function TemporaryAlert() {
                 }}
               />
             </Flex>
-            <Box
+            <Flex
+              align="center"
               csx={{
                 marginX: 2,
               }}
             >
               {formatMessage({ id: 'admin/pages.editor.newadmin.alert' })}
-            </Box>
+            </Flex>
             <Button onClick={handleOnClick}>
               {formatMessage({
                 id: 'admin/pages.editor.newadmin.alert.button',

--- a/react/components/TemporaryAlert/index.tsx
+++ b/react/components/TemporaryAlert/index.tsx
@@ -4,9 +4,9 @@ import {
   ThemeProvider,
   createSystem,
   Box,
-  Button,
   Flex,
   IconNotifications,
+  Anchor,
 } from '@vtex/admin-ui'
 import { useIntl } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -21,12 +21,7 @@ export function TemporaryAlert() {
     return null
   }
 
-  const handleOnClick = () => {
-    window.top.location.href = window.top.location.href.replace(
-      `${workspace}--`,
-      ''
-    )
-  }
+  const url = window.top.location.href.replace(`${workspace}--`, '')
 
   return (
     <ThemeProvider system={system}>
@@ -47,16 +42,18 @@ export function TemporaryAlert() {
             <Flex
               align="center"
               csx={{
-                marginX: 2,
+                marginLeft: 2,
               }}
             >
-              {formatMessage({ id: 'admin/pages.editor.newadmin.alert' })}
+              <span>
+                {formatMessage({ id: 'admin/pages.editor.newadmin.alert' })}
+                <Anchor href={url} target="_blank">
+                  {formatMessage({
+                    id: 'admin/pages.editor.newadmin.alert.anchor',
+                  })}
+                </Anchor>
+              </span>
             </Flex>
-            <Button onClick={handleOnClick}>
-              {formatMessage({
-                id: 'admin/pages.editor.newadmin.alert.button',
-              })}
-            </Button>
           </Flex>
         </Alert>
       </Box>

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@apollo/react-testing": "^3.1.3",
+    "@vtex/admin-ui": "^0.97.0",
     "classnames": "^2.2.6",
     "deep-object-diff": "^1.1.0",
     "draft-js": "^0.10.5",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -196,6 +196,13 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-module-imports@^7.12.13":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  dependencies:
+    "@babel/types" "^7.13.12"
+
 "@babel/helper-module-imports@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz#e5a92529f8888bf319a6376abfbd1cebc491ad91"
@@ -226,6 +233,11 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+
+"@babel/helper-plugin-utils@^7.12.13":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
+  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
 
 "@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
   version "7.5.5"
@@ -269,6 +281,11 @@
   integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
 "@babel/helper-wrap-function@^7.7.4":
   version "7.7.4"
@@ -396,6 +413,13 @@
   integrity sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz#044fb81ebad6698fe62c478875575bcbb9b70f15"
+  integrity sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-syntax-jsx@^7.7.4":
   version "7.7.4"
@@ -840,6 +864,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.7.2":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -873,6 +904,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.13.12":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.4.tgz#bfd6980108168593b38b3eb48a24aa026b919bc0"
+  integrity sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
+    to-fast-properties "^2.0.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -880,6 +919,112 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.2.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
+  integrity sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "^4.0.3"
+
+"@emotion/cache@^11.1.3", "@emotion/cache@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
+  integrity sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
+"@emotion/css@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.1.3.tgz#9ed44478b19e5d281ccbbd46d74d123d59be793f"
+  integrity sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==
+  dependencies:
+    "@emotion/babel-plugin" "^11.0.0"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.5":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.4.0.tgz#2465ad7b073a691409b88dfd96dc17097ddad9b7"
+  integrity sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@formatjs/intl-listformat@1.3.1":
   version "1.3.1"
@@ -1093,6 +1238,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@popperjs/core@^2.5.4":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -1320,6 +1470,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.4.tgz#2c8d58f726cfbbd9b76d179475fd386d650a2fda"
   integrity sha512-z7deEbNOPcS7pb7uyaZhbITh18ruGghYh86VmUL2zJPKeu9tEAqF0goQH0dhWamHoBJpkyWroNxPZjzNvbYVCw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/prop-types@*", "@types/prop-types@^15.5.2", "@types/prop-types@^15.7.0":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -1498,6 +1653,102 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
     tsutils "^3.17.1"
+
+"@vtex/admin-core@^0.10.10":
+  version "0.10.10"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-core/-/admin-core-0.10.10.tgz#1d444244e92a7db7a37cbf9d1c76d260357858d1"
+  integrity sha512-9o9wJ9witQNUokX9AxHklZeHZbNq1fliQD74cnCoeF10Tg71oU0RT4640anreYWZl245ljCfqGJl+332GYFrYQ==
+  dependencies:
+    "@vtex/admin-ui-system" "^0.15.1"
+    "@vtex/admin-ui-theme" "^0.26.2"
+    deepmerge "^4.2.2"
+    focus-visible "^5.1.0"
+    react-helmet "6.1.0"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+
+"@vtex/admin-illustrations@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-illustrations/-/admin-illustrations-0.1.1.tgz#35d9617bd8b2a2fbc1b9232e4bf5a673c2c0a1a9"
+  integrity sha512-B1/pTh+kPBgPyj+AIwuDS9xz9AmdH2+E8nt1cqP452dRHMG8wT+Pqvhudr5EShfbw4ICisNSdtOQCwZXSgES6A==
+
+"@vtex/admin-jsxs@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-jsxs/-/admin-jsxs-0.1.1.tgz#5c5140725759848054c8899d8a7385e0953b492a"
+  integrity sha512-KANFcuhgm7jtGRed9BtMTutbrzRPnE+jb+lbEhLhDihwieK1DyK6MXm12rNwEGYTy/TxHJGA/d0SVOI0L6/zsw==
+  dependencies:
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+
+"@vtex/admin-primitives@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-primitives/-/admin-primitives-0.4.5.tgz#981bcd74dbefcbf09739154e1b5efbbdbd161409"
+  integrity sha512-as7MWbBBwflzsikfluS5PCqvD//ji03NXpliaeTLSP1lU17WQ0ZWys30Q2F8+O3muBFmK6HdxSARtipbDY2lqw==
+
+"@vtex/admin-styles@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-styles/-/admin-styles-0.3.0.tgz#2ec990419d7907e2162f994640d8d6386af07703"
+  integrity sha512-uGMeUyM+mb+YFcKAWmZVgyqfQA7AJ8Nt1ehhHm6Y8tIeXJSI9KTXwAI/gYJF1vsmL+f4Ob1tM4PrN184DLj9YQ==
+  dependencies:
+    csstype "^3.0.5"
+    lodash.get "^4.4.2"
+    lodash.merge "^4.6.2"
+    tiny-warning "^1.0.3"
+
+"@vtex/admin-ui-icons@^0.11.4":
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-icons/-/admin-ui-icons-0.11.4.tgz#19644c3ad6319fe2cc3fbf5107c38d0080ab5033"
+  integrity sha512-s9o7K2tF5+LamP9BBRz7vQvfh3MJD7JLOAuRkLCcGxpT8lXQqeJAio2Dr5q5wiHrMhdPEQ1XOMEkDQIBrB18rQ==
+  dependencies:
+    "@vtex/admin-core" "^0.10.10"
+
+"@vtex/admin-ui-system@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-system/-/admin-ui-system-0.15.1.tgz#c0082c3e86086f6a91bcd7df6c3587a8ab0887db"
+  integrity sha512-otlbFbZiOGwgoWy6DEwKYQ0G25CwMstDXjBWy4f47gOLXdhwbQFToZ+DX2J2SQ2Aan7yU8JjF+jpXvv8EWONpA==
+  dependencies:
+    "@vtex/admin-jsxs" "^0.1.1"
+    "@vtex/admin-styles" "^0.3.0"
+    csstype "^3.0.5"
+    deepmerge "^4.2.2"
+    focus-visible "^5.1.0"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    polished "^4.0.5"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+
+"@vtex/admin-ui-theme@^0.26.2":
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui-theme/-/admin-ui-theme-0.26.2.tgz#1baad21d12b8812a2fcc51cdcfe0b89ea7507ad1"
+  integrity sha512-ANbMQ98YSalpENGYNxJnVJhfWv/2WYXoTNhGJhPSWzXvcDzgJmhknOauPTWBkbgZyKiaz/uImvsRyrSg9F5bVg==
+  dependencies:
+    polished "^4.0.3"
+
+"@vtex/admin-ui@^0.97.0":
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/@vtex/admin-ui/-/admin-ui-0.97.0.tgz#a50f3df73f1cb6b6970f74514b8ec4206472c2c9"
+  integrity sha512-9+bYpgzu7qadTAajhrREvSdQmlC3+IBO7lmdDfzny8v7GKkPe5taL5qaYi9vEAd0AJoBSbuTSMMyuu03f4hKsQ==
+  dependencies:
+    "@emotion/babel-plugin" "^11.2.0"
+    "@emotion/css" "^11.1.3"
+    "@emotion/react" "^11.1.5"
+    "@vtex/admin-core" "^0.10.10"
+    "@vtex/admin-illustrations" "^0.1.1"
+    "@vtex/admin-primitives" "^0.4.5"
+    "@vtex/admin-ui-icons" "^0.11.4"
+    csstype "^3.0.5"
+    deepmerge "^4.2.2"
+    downshift "^6.0.6"
+    focus-visible "^5.1.0"
+    framer-motion "^2.9.4"
+    polished "^3.6.7"
+    react-device-detect "^1.15.0"
+    react-is "^17.0.1"
+    reakit "^1.3.5"
+    reakit-utils "^0.14.3"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
 
 "@vtex/intl-equalizer@^2.3.0":
   version "2.4.2"
@@ -2102,6 +2353,15 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-macros@^2.6.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
+  integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    cosmiconfig "^6.0.0"
+    resolve "^1.12.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -2646,6 +2906,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+body-scroll-lock@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
+  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
+
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -2982,6 +3247,11 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+compute-scroll-into-view@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
+  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2992,7 +3262,7 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
-convert-source-map@^1.4.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -3041,6 +3311,17 @@ cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -3108,6 +3389,11 @@ csstype@^2.2.0, csstype@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
+
+csstype@^3.0.2, csstype@^3.0.5:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.5"
@@ -3178,6 +3464,11 @@ deep-object-diff@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -3339,6 +3630,16 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+downshift@^6.0.6:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.3.tgz#e794b7805d24810968f21e81ad6bdd9f3fdc40da"
+  integrity sha512-RA1MuaNcTbt0j+sVLhSs8R2oZbBXYAtdQP/V+uHhT3DoDteZzJPjlC+LQVm9T07Wpvo84QXaZtUCePLDTDwGXg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    compute-scroll-into-view "^1.0.17"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 draft-js@^0.10.5:
   version "0.10.5"
@@ -3515,6 +3816,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.9.1:
   version "1.12.1"
@@ -3997,6 +4303,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -4024,6 +4335,11 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+focus-visible@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4055,6 +4371,26 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
+
+framer-motion@^2.9.4:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-2.9.5.tgz#bbb185325d531c57f494cf3f6cf7719fc2c225c7"
+  integrity sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==
+  dependencies:
+    framesync "^4.1.0"
+    hey-listen "^1.0.8"
+    popmotion "9.0.0-rc.20"
+    style-value-types "^3.1.9"
+    tslib "^1.10.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.1.0.tgz#69a8db3ca432dc70d6a76ba882684a1497ef068a"
+  integrity sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==
+  dependencies:
+    hey-listen "^1.0.5"
 
 fs-extra@~5.0.0:
   version "5.0.0"
@@ -4316,6 +4652,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hey-listen@^1.0.5, hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -4416,6 +4757,14 @@ import-fresh@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -5330,6 +5679,11 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -5433,6 +5787,11 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 lint-staged@^9.2.3:
   version "9.5.0"
@@ -5544,10 +5903,30 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -6183,6 +6562,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
@@ -6313,6 +6702,30 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+polished@^3.6.7:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.7.2.tgz#ec5ddc17a7d322a574d5e10ddd2a6f01d3e767d1"
+  integrity sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+polished@^4.0.3, polished@^4.0.5:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.3.tgz#7a3abf2972364e7d97770b827eec9a9e64002cfc"
+  integrity sha512-ocPAcVBUOryJEKe0z2KLd1l9EBa1r5mSwlKpExmrLzsnIzJo4axsoU9O2BjOTkDGDT4mZ0WFE5XKTlR3nLnZOA==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+
+popmotion@9.0.0-rc.20:
+  version "9.0.0-rc.20"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.20.tgz#f3550042ae31957b5416793ae8723200951ad39d"
+  integrity sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==
+  dependencies:
+    framesync "^4.1.0"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.9"
+    tslib "^1.10.0"
 
 popper.js@^1.14.1:
   version "1.16.0"
@@ -6490,6 +6903,13 @@ react-apollo@^3.1.3:
     "@apollo/react-hooks" "^3.1.3"
     "@apollo/react-ssr" "^3.1.3"
 
+react-device-detect@^1.15.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.17.0.tgz#a00b4fd6880cebfab3fd8a42a79dc0290cdddca9"
+  integrity sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==
+  dependencies:
+    ua-parser-js "^0.7.24"
+
 react-dom@^16.8.1, react-dom@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -6508,6 +6928,21 @@ react-dropzone@^10.1.3:
     attr-accept "^2.0.0"
     file-selector "^0.1.12"
     prop-types "^15.7.2"
+
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-input-autosize@^2.1.2:
   version "2.2.2"
@@ -6539,6 +6974,11 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-is@^17.0.1, react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-jsonschema-form@^1.0.1:
   version "1.8.1"
@@ -6596,6 +7036,11 @@ react-select@^1.2.1:
     classnames "^2.2.4"
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-sortable-hoc@^1.9.1:
   version "1.10.1"
@@ -6686,6 +7131,41 @@ readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+reakit-system@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/reakit-system/-/reakit-system-0.15.1.tgz#bf5cc7a03f60a817373bc9cbb4a689c1f4100547"
+  integrity sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==
+  dependencies:
+    reakit-utils "^0.15.1"
+
+reakit-utils@^0.14.3:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.14.4.tgz#1ecf035faf58960ba48eac2963f70269596effcf"
+  integrity sha512-jDEf/NmZVJ6fs10G16ifD+RFhQikSLN7VfjRHu0CPoUj4g6lFXd5PPcRXCY81qiqc9FVHjr2d2fmsw1hs6xUxA==
+
+reakit-utils@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.15.1.tgz#797f0a43f6a1dbc22d161224d5d2272e287dbfe3"
+  integrity sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q==
+
+reakit-warning@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/reakit-warning/-/reakit-warning-0.6.1.tgz#dba33bb8866aebe30e67ac433ead707d16d38a36"
+  integrity sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==
+  dependencies:
+    reakit-utils "^0.15.1"
+
+reakit@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.8.tgz#717e1a3b7cc6da803362a0edc2c55d2b6a001baf"
+  integrity sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==
+  dependencies:
+    "@popperjs/core" "^2.5.4"
+    body-scroll-lock "^3.1.5"
+    reakit-system "^0.15.1"
+    reakit-utils "^0.15.1"
+    reakit-warning "^0.6.1"
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
@@ -6727,6 +7207,11 @@ regenerator-runtime@^0.13.1, regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -7260,7 +7745,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -7520,6 +8005,19 @@ structured-source@^3.0.2:
   dependencies:
     boundary "^1.0.1"
 
+style-value-types@^3.1.9:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.2.0.tgz#eb89cab1340823fa7876f3e289d29d99c92111bb"
+  integrity sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
+stylis@^4.0.3:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -7594,7 +8092,12 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -7753,6 +8256,11 @@ ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
+ua-parser-js@^0.7.24:
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 uglify-js@^3.1.4:
   version "3.7.4"
@@ -8186,6 +8694,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yaml@^1.7.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^13.1.1:
   version "13.1.1"


### PR DESCRIPTION
#### What problem is this solving?

Warns customers on the `newadmin` production workspaces, which hosts the Admin's beta version, to navigate back to the master workspace in case they want to edit their stores.

#### How should this be manually tested?

Navigate to this [workspace](https://newadmin--teamadmin.myvtex.com/admin/cms/site-editor) and make sure that you see an alert on top of the Site Editor 😉 

NOTE: Although you'll see the yellow, development banner, this won't be true once this PR is merged, because the linked version doesn't contain the `production` check.

NOTE 2: These changes should only be apparent for customers on the `admin@4.x`, which doesn't have the same amount of languages available as the `admin@3.x`, thus, there are English translations placed on other languages, as the CI will fail in case the `intl-equalizer` doesn't find the same translation keys in all files.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️   | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

For more context on these changes, please reach #team-admin on Slack.
