### PR TITLE
Shorten message from the temporary newadmin workspace warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Shortened the message from the temporary warning banner for the `newadmin` workspaces.
+
 ## [4.43.0] - 2021-06-07
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Lazily render the page footer and lazily loads its assets, which helps improving the performance of the first render of the page.",
   "admin/store.advancedSettings.enableLazyFold.title": "Enable lazy loading of assets below-the-fold",
   "admin/store.advancedSettings.enableLazyFold.description": "Enables lazy loading of the JS files of the components below the `__fold__` block.",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Representa el pie de página y carga los recursos de forma Lazy, lo que ayuda a mejorar el rendimiento de la primera representación de la página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar la carga Lazy de recursos en el bloque inferior",
   "admin/store.advancedSettings.enableLazyFold.description": "Permite la carga diferida de los archivos JS de los componentes (above the fold)",
-  "admin/pages.editor.newadmin.alert": "Site Editor funciona como un ambiente de prueba en la versión beta del Admin VTEX. Para que los cambios se apliquen en su tienda online, ",
-  "admin/pages.editor.newadmin.alert.anchor": "acceda a la versión anterior del Admin."
+  "admin/pages.editor.newadmin.alert": "Este es un ambiente de prueba. Para aplicar los cambios en su tienda online, ",
+  "admin/pages.editor.newadmin.alert.anchor": "por favor acceda al VTEX Admin anterior."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Rendu différé du pied de page et chargement différé de ses actifs, permettant d'améliorer les performances du premier rendu de la page.",
   "admin/store.advancedSettings.enableLazyFold.title": "Activez le chargement différé des ressources sous la ligne de flottaison (fold)",
   "admin/store.advancedSettings.enableLazyFold.description": "Permet le chargement différé des fichiers JS des composants situés sous le bloc `__fold__`.",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Esegui il rendering differito del piè di pagina ed esegui il caricamento differito delle rispettive attività. Ciò migliora le prestazioni del primo rendering della pagina.",
   "admin/store.advancedSettings.enableLazyFold.title": "Abilita il caricamento differito delle risorse \"Below the Fold\"",
   "admin/store.advancedSettings.enableLazyFold.description": "Abilita il caricamento differito del file JS dei componenti del blocco \"Below the __fold__\".",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description":"ページフッターのレンダリングやそのアセットの読み込みを遅延させます。こうするとページの最初のレンダリングのパフォーマンスが改善されます。",
   "admin/store.advancedSettings.enableLazyFold.title":"ファーストビュー領域以外のアセットの遅延読み込みを有効にする",
   "admin/store.advancedSettings.enableLazyFold.description":"`__fold__` ブロックより下にあるコンポーネントの JS ファイルの遅延読み込みを有効にします。",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "페이지 푸터를 지연 렌더링하고 자산을 지연 로드하여, 페이지의 첫 번째 렌더링 성능을 개선하는 데 도움이 됩니다.",
   "admin/store.advancedSettings.enableLazyFold.title": "폴더 아래쪽 자산의 지연 로드 사용",
   "admin/store.advancedSettings.enableLazyFold.description": "'__fold__' 블록 아래에 있는 구성 요소의 JS 파일을 지연 로드할 수 있습니다.",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Render de voettekst van de pagina op een trage manier en laadt de assets op een trage manier, wat de prestaties van de eerste render van de pagina ten goede komt.",
   "admin/store.advancedSettings.enableLazyFold.title": "Schakel traag laden van activa onder de vouw in",
   "admin/store.advancedSettings.enableLazyFold.description": "Schakel het traag laden in van de JS bestanden van de componenten onder het `__fold__` blok in.",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Renderiza de forma Lazy o rodapé da página e o carregamento de seus ativos, o que ajuda a melhorar o desempenho da primeira renderização da página.",
   "admin/store.advancedSettings.enableLazyFold.title": "Habilitar o carregamento de forma Lazy de ativos abaixo da dobra",
   "admin/store.advancedSettings.enableLazyFold.description": "Permite o carregamento de forma Lazy dos arquivos JS dos componentes (above the fold)",
-  "admin/pages.editor.newadmin.alert": "O Site Editor funciona como um ambiente teste nesta versão Beta do Admin da VTEX. Para aplicar mudanças na sua loja online, ",
-  "admin/pages.editor.newadmin.alert.anchor": "por favor acesse o ambiente do Admin anterior."
+  "admin/pages.editor.newadmin.alert": "Este é um ambiente teste. Para aplicar mudanças na sua loja online, ",
+  "admin/pages.editor.newadmin.alert.anchor": "por favor acesse o Admin VTEX anterior."
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -552,6 +552,6 @@
   "admin/store.advancedSettings.enableLazyFooter.description": "Redă în mod lent footer-ul paginii şi încarcă lent activele sale, ceea ce ajută la îmbunătăţirea performanţei la prima redare a paginii.",
   "admin/store.advancedSettings.enableLazyFold.title": "Activează încărcarea lentă a activelor de dedesubt.",
   "admin/store.advancedSettings.enableLazyFold.description": "Activează încărcarea lentă a fişierelor JS a componentelor de sub elementul __fold__.",
-  "admin/pages.editor.newadmin.alert": "Site Editor works as a test environment for the VTEX Admin in Beta version. For applying changes to your online store, ",
-  "admin/pages.editor.newadmin.alert.anchor": "please use the previous Admin environment."
+  "admin/pages.editor.newadmin.alert": "This is a test environment. To apply changes to your online store, ",
+  "admin/pages.editor.newadmin.alert.anchor": "please access the previous VTEX Admin."
 }


### PR DESCRIPTION
#### What problem is this solving?

Shorten message from the temporary `newadmin` workspace warning. 

Related thread on Slack: https://vtex.slack.com/archives/C01KE2JBL5P/p1623159536005400

#### How should this be manually tested?

[Workspace](https://marcelo--teamadmin.myvtex.com/admin/cms/site-editor)

NOTE: The workspace above has changes that are not reflected on this PR in order for it to appear since it should only be displayed on `production` workspaces named `newadmin`.

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| ✔️   | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

For more context on this, please reach #team-admin on Slack.

#### Related

https://github.com/vtex-apps/admin-pages/pull/390