### PR TITLE
Fix: Update routes listing when a binding user route is created from …

### DIFF
--- a/react/components/admin/pages/Form/utils.ts
+++ b/react/components/admin/pages/Form/utils.ts
@@ -98,11 +98,20 @@ export const updateStoreAfterSave = (
 
       const savedRouteId = savedRoute && savedRoute.uuid
       const matchedRoute = routes.find(route => route.uuid === savedRouteId)
+      const appRouteIdx = routes.findIndex(
+        route =>
+          route.declarer && !route.binding && route.path === savedRoute.path
+      )
+
       if (matchedRoute) {
         const idx = routes.indexOf(matchedRoute)
         routes[idx] = savedRoute
       } else {
         routes.push(savedRoute)
+      }
+
+      if (appRouteIdx !== -1) {
+        routes.splice(appRouteIdx, 1)
       }
 
       const newData = {


### PR DESCRIPTION
#### What problem is this solving?

Today, the routes listing on the Content Management/Pages admin section is not considering multi-binding. We can create a user route from an app route, but it's showed only on the first binding edited. The idea is to be possible to create a user route for each binding. If there isn't a user route, the app route should be shown.

#### How should this be manually tested?

[Workspace](https://vitorflg--smartcsb2c.myvtex.com/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

Depends on [pages-graphql](https://github.com/vtex/pages-graphql/pull/398)

