### PR TITLE
fix: quantity of redirects being displayed on list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fix the number of redirects displayed on cms/redirects
 
 ## [4.44.3] - 2021-07-27
 

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -81,7 +81,7 @@ const RedirectList: React.FC<Props> = ({
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   const [
-    { paginationFrom, paginationTo: statePaginationTo },
+    { paginationFrom, paginationTo },
     setPagination,
   ] = useState({
     paginationFrom: PAGINATION_START,
@@ -91,8 +91,6 @@ const RedirectList: React.FC<Props> = ({
   const [alertState, setAlert] = useState<AlertState | null>(null)
 
   const [isImportErrorModalOpen, setIsImportErrorModalOpen] = useState(false)
-
-  const paginationTo = statePaginationTo && statePaginationTo - 1
 
   const openModal = useCallback(() => {
     setIsModalOpen(true)
@@ -163,7 +161,7 @@ const RedirectList: React.FC<Props> = ({
     if (!nextToken && paginationFrom >= dataLength) {
       return
     }
-    const maybeNextPaginationTo = paginationTo + PAGINATION_STEP + 1
+    const maybeNextPaginationTo = paginationTo + PAGINATION_STEP
 
     if (maybeNextPaginationTo > dataLength && nextToken) {
       await fetchMore({
@@ -292,7 +290,7 @@ const RedirectList: React.FC<Props> = ({
                     {redirects.length > 0 && (
                       <Pagination
                         currentItemFrom={paginationFrom + 1}
-                        currentItemTo={paginationTo + 1}
+                        currentItemTo={paginationTo}
                         onNextClick={getNextPageNavigationHandler(
                           redirects.length,
                           fetchMore,


### PR DESCRIPTION
#### What problem is this solving?

The number of redirects displayed on cms/redirects screen is less than it should

Showing 9
Should be 10

#### How should this be manually tested?

1 - Go to any account at admin/cms/redirects
2 - Check the number of redirects in the list, it should display 10, but, it's displaying 9
3 - With the fix, should display 10

[Workspace](https://redirects--storecomponents.myvtex.com/admin/cms/redirects/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

Before

![image](https://user-images.githubusercontent.com/13649073/126344102-d39667de-81f5-44e9-a99b-7c4640527428.png)


After

![image](https://user-images.githubusercontent.com/13649073/126343803-e574e9e7-8e4b-402b-92e7-ddd44791a767.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3tEFVAbfzzcwo/giphy.gif)
