### PR TITLE
NAD-618 - Add store module on `admin@4.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Store module under the `Store Settings/Storefront` section on `admin@4.x`.
+
 ## [4.44.6] - 2021-07-30
 
 ### Fixed
@@ -19,8 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Toast overflows the bottom-right conner, making the app unresponsive in that section.
 
-
 ## [4.44.4] - 2021-07-27
+
 ### Fixed
 
 - Fix the number of redirects displayed on cms/redirects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Store module under the `Store Settings/Storefront` section on `admin@4.x`.
+- Store module under the `Store Settings/Storefront` sidebar section of the `admin@4.x`.
 
 ## [4.44.6] - 2021-07-30
 

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -54,24 +54,31 @@
           "index": 0,
           "operation": "add"
         },
-        "isNew": true,
         "labelId": "admin/pages.admin-menu-button.site-editor",
         "path": "/admin/cms/site-editor"
       },
       {
-        "isNew": true,
         "labelId": "admin/pages.admin-menu-button.pages",
         "path": "/admin/cms/pages"
       },
       {
-        "isNew": true,
         "labelId": "admin/pages.admin-menu-button.styles",
         "path": "/admin/cms/styles"
       },
       {
-        "isNew": true,
         "labelId": "admin/pages.admin.tabs.redirects",
         "path": "/admin/cms/redirects"
+      }
+    ]
+  },
+  {
+    "section": "storeSettings",
+    "subSection": "storeFront",
+    "adminVersion": 4,
+    "subSectionItems": [
+      {
+        "labelId": "admin/pages.admin-menu-button.store",
+        "path": "/admin/cms/store"
       }
     ]
   }


### PR DESCRIPTION
#### What problem is this solving?

Currently, the `store` module is not available on `admin@4.x`'s sidebar. This PR includes the `store` module on the sidebar.

#### How should this be manually tested?

Compare both workspaces, the current one without the changes from this PR: https://teamadmin.myvtex.com/admin/cms/store (notice how you'll be able to visit the module, but it is not mapped to the sidebar)

And the one with these changes, where the navigation UX is complete: https://store--teamadmin.myvtex.com/admin/cms/store

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| ✔️  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

For more information about this, take a glance at this Jira ticket: https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=300&projectKey=NAD&modal=detail&selectedIssue=NAD-618
