### PR TITLE
CMS-590 - Warn users about the behavior of changes on subcategory pages

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -2,7 +2,7 @@
 src
 
 .gitignore
-CHANGELOG.md
+./CHANGELOG.md
 README.md
 
 **/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Disable editor changes in subcategory pages.
+
 ## [4.47.1] - 2022-05-19
 
 ### Changed
 - Upgrade the dependency `admin-cms` to 1.x.
 
 ## [4.47.0] - 2022-02-23
+
 ### Added
+
 - I18n for new settings
 
 ## [4.46.3] - 2021-12-21

--- a/messages/context.json
+++ b/messages/context.json
@@ -167,6 +167,7 @@
   "admin/pages.editor.component-list.untitled": "admin/pages.editor.component-list.untitled",
   "admin/pages.editor.components.arrayTemplate.button.add": "admin/pages.editor.components.arrayTemplate.button.add",
   "admin/pages.editor.components.status.alert": "admin/pages.editor.components.status.alert",
+  "admin/pages.editor.components.editable.alert": "admin/pages.editor.components.editable.alert",
   "admin/pages.editor.components.button.cancel": "admin/pages.editor.components.button.cancel",
   "admin/pages.editor.components.button.save": "admin/pages.editor.components.button.save",
   "admin/pages.editor.components.condition.date.title": "admin/pages.editor.components.condition.date.title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -166,7 +166,7 @@
   "admin/pages.editor.component-list.title": "Versions",
   "admin/pages.editor.component-list.untitled": "Untitled Block",
   "admin/pages.editor.components.status.alert": "This version of the content is not being shown in the preview and to visitors.",
-  "admin/pages.editor.components.editable.alert": "You can’t edit this content. All content in this page is inherited from its parent level.",
+  "admin/pages.editor.components.editable.alert": "Editing this page will reflect on every subcategory page. If you want to have the content inherited from its parent(category) level, reset it.",
   "admin/pages.editor.components.arrayTemplate.button.add": "Add",
   "admin/pages.editor.components.button.cancel": "Cancel",
   "admin/pages.editor.components.button.save": "Save",

--- a/messages/en.json
+++ b/messages/en.json
@@ -166,6 +166,7 @@
   "admin/pages.editor.component-list.title": "Versions",
   "admin/pages.editor.component-list.untitled": "Untitled Block",
   "admin/pages.editor.components.status.alert": "This version of the content is not being shown in the preview and to visitors.",
+  "admin/pages.editor.components.editable.alert": "You can’t edit this content. All content in this page is inherited from its parent level.",
   "admin/pages.editor.components.arrayTemplate.button.add": "Add",
   "admin/pages.editor.components.button.cancel": "Cancel",
   "admin/pages.editor.components.button.save": "Save",

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/Form.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/Form.tsx
@@ -27,11 +27,7 @@ export const widgets: Record<string, Widget> = {
   'image-uploader': (MediaGalleryWidget as unknown) as Widget,
 }
 
-type CustomProps = {
-  isSubcategoryPage: boolean
-}
-
-type Props = FormProps<FormDataContainer> & CustomProps
+type Props = FormProps<FormDataContainer>
 export default class Form extends React.Component<Props> {
   public shouldComponentUpdate(nextProps: Props) {
     return (
@@ -43,7 +39,6 @@ export default class Form extends React.Component<Props> {
   public render() {
     return (
       <JsonSchemaForm
-        disabled={this.props.isSubcategoryPage}
         schema={this.props.schema}
         formData={this.props.formData}
         onChange={this.props.onChange}

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/Form.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/Form.tsx
@@ -27,7 +27,11 @@ export const widgets: Record<string, Widget> = {
   'image-uploader': (MediaGalleryWidget as unknown) as Widget,
 }
 
-type Props = FormProps<FormDataContainer>
+type CustomProps = {
+  isSubcategoryPage: boolean
+}
+
+type Props = FormProps<FormDataContainer> & CustomProps
 export default class Form extends React.Component<Props> {
   public shouldComponentUpdate(nextProps: Props) {
     return (
@@ -39,6 +43,7 @@ export default class Form extends React.Component<Props> {
   public render() {
     return (
       <JsonSchemaForm
+        disabled={this.props.isSubcategoryPage}
         schema={this.props.schema}
         formData={this.props.formData}
         onChange={this.props.onChange}

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
@@ -184,6 +184,11 @@ const BlockConfigurationEditor: React.FunctionComponent<Props> = ({
     statement => statement.verb === 'to'
   )
 
+  const isSubcategoryPage = !!(
+    iframeRuntime.route.pageContext?.id === 'search' &&
+    iframeRuntime.route.pageContext?.type === 'subcategory'
+  )
+
   const getStatusWarningText = () => {
     if (statusFromRuntime === ConfigurationStatus.ACTIVE) {
       return intl.formatMessage(messages.activationDisabledLabel)
@@ -214,6 +219,15 @@ const BlockConfigurationEditor: React.FunctionComponent<Props> = ({
               <FormattedMessage
                 id="admin/pages.editor.components.status.alert"
                 defaultMessage="This version of the content is not being shown in the preview and to visitors."
+              />
+            </p>
+          )}
+
+          {isSubcategoryPage && (
+            <p className="pt4 pb4 pl4 pr2 bg-warning--faded lh-copy">
+              <FormattedMessage
+                id="admin/pages.editor.components.editable.alert"
+                defaultMessage="You can’t edit this content. All content in this page is inherited from its parent level."
               />
             </p>
           )}
@@ -248,6 +262,7 @@ const BlockConfigurationEditor: React.FunctionComponent<Props> = ({
               popComponentFormState,
               pushComponentFormState,
             }}
+            isSubcategoryPage={isSubcategoryPage}
             formData={data}
             onChange={onChange}
             onSubmit={onSave}

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
@@ -262,7 +262,6 @@ const BlockConfigurationEditor: React.FunctionComponent<Props> = ({
               popComponentFormState,
               pushComponentFormState,
             }}
-            isSubcategoryPage={isSubcategoryPage}
             formData={data}
             onChange={onChange}
             onSubmit={onSave}

--- a/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/BlockConfigurationEditor/index.tsx
@@ -227,7 +227,7 @@ const BlockConfigurationEditor: React.FunctionComponent<Props> = ({
             <p className="pt4 pb4 pl4 pr2 bg-warning--faded lh-copy">
               <FormattedMessage
                 id="admin/pages.editor.components.editable.alert"
-                defaultMessage="You can’t edit this content. All content in this page is inherited from its parent level."
+                defaultMessage="Editing this page will reflect on every subcategory page. If you want to have the content inherited from its parent(category) level, reset it."
               />
             </p>
           )}

--- a/react/components/EditorContainer/Sidebar/BlockEditor/hooks.ts
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/hooks.ts
@@ -190,6 +190,7 @@ export const useFormHandlers: UseFormHandlers = ({
       await saveContent({
         variables: {
           bindingId: iframeRuntime.binding?.id,
+          route: iframeRuntime.route,
           blockId,
           configuration: newConfiguration,
           lang: iframeRuntime.culture.locale,

--- a/react/components/EditorContainer/graphql/SaveContent.graphql
+++ b/react/components/EditorContainer/graphql/SaveContent.graphql
@@ -1,5 +1,6 @@
 mutation saveContent(
   $bindingId: String
+  $route: JSONObject
   $blockId: String
   $configuration: ContentConfigurationInput
   $template: String
@@ -8,6 +9,7 @@ mutation saveContent(
 ) {
   saveContent(
     bindingId: $bindingId
+    route: $route
     blockId: $blockId
     configuration: $configuration
     template: $template


### PR DESCRIPTION
#### What problem is this solving?

Since subcategory pages can't have their own context, it's not possible to differentiate their content.
Example > If in the Site Editor, within a category page(/tshirts), I filter the results using a 'blue' option(/thirts/blue), any changes to this page content(banner/rich-text...) will be reflected in all subcategory pages(tshirts/red, tshirts/v-neck...)

To avoid this unintended result, we will be warning users to reset subcategory content to make it be inherited from its parent category.

#### How should this be manually tested?
1. Go to the [workspace](https://vitorflg--storecomponents.myvtex.com/admin/cms/site-editor/apparel---accessories/clothing/white)
2. Make sure the actions are blocked and a warning is advising the default behavior 


<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

- I'm still talking with Vedotti to check if it's not safer to permit actions and only warn users about the current behavior.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

X
