### PR TITLE
Adding a redirect searcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - 2023-06-05
+### Added
+- Redirects searcher
 
 ## [4.50.0] - 2023-04-03
 

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -25,11 +25,12 @@ import {
 } from './components/admin/TargetPathContext'
 import Redirects from './queries/Redirects.graphql'
 
-type Props = CustomProps & WithApolloClient<TargetPathContextProps>
-
 interface CustomProps {
   hasMultipleBindings: boolean
 }
+
+type Props = CustomProps & WithApolloClient<TargetPathContextProps>
+
 interface RedirectListQueryResult {
   redirect: {
     listRedirects: {
@@ -141,7 +142,7 @@ const RedirectList: React.FC<Props> = ({
         const bindingString = hasMultipleBindings ? `${binding || ''};` : ''
         writer.write(
           textEncoder.encode(
-            `${from};${to};${type};${bindingString}${endDate || ''}\n`
+            `${from};${to};${type};${bindingString}${endDate ?? ''}\n`
           )
         )
       })
@@ -215,14 +216,14 @@ const RedirectList: React.FC<Props> = ({
         }}
       >
         {({ data, fetchMore, loading, refetch, error }) => {
-          const redirects = data?.redirect?.listRedirects.routes || []
+          const redirects = data?.redirect?.listRedirects.routes ?? []
           const hasRedirects = redirects.length > 0
 
           const handleInputSearchChange = (
             e: React.ChangeEvent<HTMLInputElement>
           ) => {
             const filteredRedirects = redirects.filter(item =>
-              item.from.includes(e.target.value)
+              item.from.toLowerCase().includes(e.target.value.toLowerCase())
             )
 
             const next = data?.redirect?.listRedirects.next

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -80,10 +80,7 @@ const RedirectList: React.FC<Props> = ({
 
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const [
-    { paginationFrom, paginationTo },
-    setPagination,
-  ] = useState({
+  const [{ paginationFrom, paginationTo }, setPagination] = useState({
     paginationFrom: PAGINATION_START,
     paginationTo: PAGINATION_START + PAGINATION_STEP,
   })
@@ -91,6 +88,8 @@ const RedirectList: React.FC<Props> = ({
   const [alertState, setAlert] = useState<AlertState | null>(null)
 
   const [isImportErrorModalOpen, setIsImportErrorModalOpen] = useState(false)
+
+  const [redirectList, setRedirectList] = useState<Redirect[]>([])
 
   const openModal = useCallback(() => {
     setIsModalOpen(true)
@@ -219,6 +218,20 @@ const RedirectList: React.FC<Props> = ({
           const redirects = data?.redirect?.listRedirects.routes || []
           const hasRedirects = redirects.length > 0
 
+          const handleInputSearchChange = (
+            e: React.ChangeEvent<HTMLInputElement>
+          ) => {
+            const filteredRedirects = redirects.filter(item =>
+              item.from.includes(e.target.value)
+            )
+
+            const next = data?.redirect?.listRedirects.next
+            if (!filteredRedirects.length && next) {
+              refetch({ limit: REDIRECTS_LIMIT, next })
+            }
+            setRedirectList(filteredRedirects)
+          }
+
           if (error) {
             return (
               <>
@@ -276,7 +289,10 @@ const RedirectList: React.FC<Props> = ({
                     <List
                       loading={loading}
                       from={paginationFrom}
-                      items={redirects.slice(paginationFrom, paginationTo)}
+                      items={(redirectList.length
+                        ? redirectList
+                        : redirects
+                      ).slice(paginationFrom, paginationTo)}
                       refetch={() => {
                         refetch({
                           limit: REDIRECTS_LIMIT,
@@ -286,6 +302,7 @@ const RedirectList: React.FC<Props> = ({
                       showToast={showToast}
                       openModal={openModal}
                       onHandleDownload={handleDownload}
+                      onHandleInputSearchChange={handleInputSearchChange}
                     />
                     {redirects.length > 0 && (
                       <Pagination

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -19,6 +19,7 @@ interface CustomProps {
   items: Redirect[]
   loading: boolean
   onHandleDownload: () => void
+  onHandleInputSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   openModal: () => void
   refetch: () => void
   showToast: ToastConsumerFunctions['showToast']
@@ -33,8 +34,8 @@ interface Schema {
 }
 
 enum CellData {
-  TEMPORARY = "TEMPORARY",
-  PERMANENT = "PERMANENT"
+  TEMPORARY = 'TEMPORARY',
+  PERMANENT = 'PERMANENT',
 }
 
 const getBindingAddress = (bindingId: string, storeBindings: Binding[]) =>
@@ -114,6 +115,7 @@ const List: React.FC<Props> = ({
   items,
   loading,
   onHandleDownload,
+  onHandleInputSearchChange,
   openModal,
   storeBindings,
 }) => {
@@ -184,6 +186,9 @@ const List: React.FC<Props> = ({
         </div>
       }
       toolbar={{
+        inputSearch: {
+          onChange: onHandleInputSearchChange,
+        },
         density: {
           buttonLabel: intl.formatMessage(messages.lineDensityLabel),
           highOptionLabel: intl.formatMessage(messages.lineDensityHigh),

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -3,7 +3,12 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "jsx": "preserve",
-    "lib": ["es2019", "dom", "es2018.promise", "esnext.asynciterable"],
+    "lib": [
+      "es2019",
+      "dom",
+      "es2018.promise",
+      "esnext.asynciterable"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -18,7 +23,11 @@
     "strictPropertyInitialization": true,
     "target": "es2017"
   },
-  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
+  "include": [
+    "./typings/*.d.ts",
+    "./**/*.tsx",
+    "./**/*.ts"
+  ],
   "typeAcquisition": {
     "enable": false
   }


### PR DESCRIPTION
#### What problem is this solving?
Now with this feature, it will be easier to search on redirects.
Having the opportunity to just type part of the page of redirect and avoiding searching page by page.
This special useful when there are more than 1000 redirects in the site
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://test--felipedev.myvtex.com/admin/cms/redirects/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
![image](https://github.com/vtex-apps/admin-pages/assets/75274040/0a162ebb-2173-4ff9-bb6b-de59e1a6420c)

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️| New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/FQaQtdbLnk676/giphy.gif)