### PR TITLE
fix: end date not displaying in redirects list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix exhibition of the end date of temporary redirects.
+
 ## [4.50.0] - 2023-04-03
 
 ### Added

--- a/react/components/admin/redirects/List/List.tsx
+++ b/react/components/admin/redirects/List/List.tsx
@@ -88,8 +88,8 @@ function getSchema(intl: IntlShape, locale: string, storeBindings: Binding[]) {
       },
       ...bindingProperty,
       endDate: {
-        cellRenderer: function EndDate(cell: { cellData: CellData }) {
-          cell.cellData ? (
+        cellRenderer: function EndDate(cell: { cellData: string }) {
+          return cell.cellData ? (
             <span className="ph4">
               {getFormattedLocalizedDate(cell.cellData, locale)}
             </span>

--- a/react/utils/date/index.ts
+++ b/react/utils/date/index.ts
@@ -7,14 +7,8 @@ export const getFirstTime = (date: Date) =>
 
 export const getFormattedLocalizedDate = (date: string, locale: string) =>
   moment(date)
-    .toDate()
-    .toLocaleDateString(locale, {
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    })
+    .locale(locale)
+    .format("lll")
 
 export const getLastTime = (date: Date) => {
   const dateClone = new Date(date)


### PR DESCRIPTION
#### What problem is this solving?

The redirects page was not showing up the end date of temporary redirects 

#### How should this be manually tested?

[Before](https://carolcanelas.myvtex.com/admin/cms/redirects/):
Enter a redirect page on the CMS module and try to look for the end date on the UI
<img width="1020" alt="image" src="https://github.com/vtex-apps/admin-pages/assets/95254650/62efbca9-fd3a-436b-b221-010c7c97e31f">

[After](https://carolteste--carolcanelas.myvtex.com/admin/cms/redirects/):
Now you can see the end date on the redirects UI
<img width="992" alt="image" src="https://github.com/vtex-apps/admin-pages/assets/95254650/3675d2d3-1daf-4afd-a9dd-cc1906b94bbd">

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

Zendesk Ticket: #833375

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/hZj44bR9FVI3K/giphy.gif)
