### PR TITLE
Fix/redirect searcher

### DIFF
--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -91,6 +91,7 @@ const RedirectList: React.FC<Props> = ({
   const [isImportErrorModalOpen, setIsImportErrorModalOpen] = useState(false)
 
   const [redirectList, setRedirectList] = useState<Redirect[]>([])
+  const [filtered, setFiltered] = useState<boolean>(false)
 
   const openModal = useCallback(() => {
     setIsModalOpen(true)
@@ -219,12 +220,18 @@ const RedirectList: React.FC<Props> = ({
           const redirects = data?.redirect?.listRedirects.routes ?? []
           const hasRedirects = redirects.length > 0
 
-          const handleInputSearchChange = (
-            e: React.ChangeEvent<HTMLInputElement>
+          const handleInputSearchChange = async (
+            e: React.ChangeEvent<HTMLInputElement>,
+            innerData: RedirectListQueryResult | undefined = undefined
           ) => {
-            const filteredRedirects = redirects.filter(item =>
-              item.from.toLowerCase().includes(e.target.value.toLowerCase())
-            )
+            e.persist()
+
+            const term = e.target.value.toLowerCase()
+            const innerRedirects = innerData?.redirect?.listRedirects.routes
+            const filteredRedirects = (innerRedirects?.length
+              ? innerRedirects
+              : redirects
+            ).filter(item => item.from.toLowerCase().includes(term))
 
             if (paginationFrom > PAGINATION_START) {
               setPagination({
@@ -233,11 +240,21 @@ const RedirectList: React.FC<Props> = ({
               })
             }
 
-            const next = data?.redirect?.listRedirects.next
+            const innerNext = innerData?.redirect?.listRedirects.next
+            const next = innerNext ?? data?.redirect?.listRedirects.next
+
             if (!filteredRedirects.length && next) {
-              refetch({ limit: REDIRECTS_LIMIT, next })
+              const { data } = await refetch({ limit: REDIRECTS_LIMIT, next })
+              handleInputSearchChange(e, data)
+            } else {
+              setRedirectList(filteredRedirects)
             }
-            setRedirectList(filteredRedirects)
+
+            if (term.length) {
+              setFiltered(true)
+            } else {
+              setFiltered(false)
+            }
           }
 
           if (error) {
@@ -297,10 +314,10 @@ const RedirectList: React.FC<Props> = ({
                     <List
                       loading={loading}
                       from={paginationFrom}
-                      items={(redirectList.length
-                        ? redirectList
-                        : redirects
-                      ).slice(paginationFrom, paginationTo)}
+                      items={(filtered ? redirectList : redirects).slice(
+                        paginationFrom,
+                        paginationTo
+                      )}
                       refetch={() => {
                         refetch({
                           limit: REDIRECTS_LIMIT,

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -226,6 +226,13 @@ const RedirectList: React.FC<Props> = ({
               item.from.toLowerCase().includes(e.target.value.toLowerCase())
             )
 
+            if (paginationFrom > PAGINATION_START) {
+              setPagination({
+                paginationFrom: PAGINATION_START,
+                paginationTo: PAGINATION_START + PAGINATION_STEP,
+              })
+            }
+
             const next = data?.redirect?.listRedirects.next
             if (!filteredRedirects.length && next) {
               refetch({ limit: REDIRECTS_LIMIT, next })


### PR DESCRIPTION
#### What problem is this solving?
When you try to search a term from the second page, the searcher will not list the results
![screen-redirect](https://github.com/vtex-apps/admin-pages/assets/75274040/dd62e2af-70f2-48a3-ba18-44495152d3bd)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

1.  Go to [Redirects page](https://redirect--felipedev.myvtex.com/admin/cms/redirects/)
2.  Go to second page.
3.  In search bar type a page (e.g. cubo-multiusos)
4.  You can see now that result is showed on screen.

#### Screenshots or example usage
![screen-fixed](https://github.com/vtex-apps/admin-pages/assets/75274040/9130eb05-3678-4af0-89da-27cc7a11530c)


<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->



#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3NtY188QaxDdC/giphy.gif)
