### PR TITLE
fix: when user changed the path of an existent route it only changed the path but not the routeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Not allow user to change the path of existing route
+
 ## [4.53.1] - 2024-01-17
 
 ## [4.53.0] - 2023-12-20

--- a/react/components/admin/pages/Form/Form.tsx
+++ b/react/components/admin/pages/Form/Form.tsx
@@ -19,6 +19,7 @@ import {
   ConditionalTemplateSection,
   ConditionalTemplateSectionProps,
 } from './ConditionalTemplateSection'
+import { isNewRoute } from '../utils'
 import { DropdownChangeInput } from '../../../../utils/bindings/typings'
 import { getBindingSelectorOptions } from '../../../../utils/bindings'
 
@@ -145,6 +146,7 @@ const Form: React.FunctionComponent<Props> = ({
 }) => {
   const intl = useIntl()
   const path = data.path || ''
+  const shouldDisablePathChange = !isNewRoute(data)
 
   const bindingOptions = useMemo(
     () => getBindingSelectorOptions(storeBindings),
@@ -178,7 +180,7 @@ const Form: React.FunctionComponent<Props> = ({
       />
       <FormFieldSeparator />
       <Input
-        disabled={!isInfoEditable}
+        disabled={shouldDisablePathChange}
         label={intl.formatMessage(messages.fieldPath)}
         onChange={detailChangeHandlerGetter('path')}
         placeholder={intl.formatMessage(messages.pathHint)}
@@ -232,9 +234,9 @@ const Form: React.FunctionComponent<Props> = ({
             onChange={detailChangeHandlerGetter('metaTagRobots')}
             value={data.metaTagRobots}
             helpText={intl.formatMessage(messages.seoRobotsHelp)}
-          />          
+          />
         </>
-      )}      
+      )}
       <SeparatorWithLine />
       <ConditionalTemplateSection
         intl={intl}


### PR DESCRIPTION
#### What problem is this solving?

The main point regarding this issue is that when users change the path of an existent route, we change the path in the routes.json, but we don't change the route id, and we validate if the route already exists or not by the routeId.

What happened is that we were creating a problem when users try to create a new route with the path that was replaced.

For example:

We create a route called `/foo`
We change the route `/foo` to `/foo2`
Now we can't create a new `/foo`

This issue caused a lot of support tickets requesting to identify and remove the duplicated/problematic route due to this usage.

The purpose here is to deny users to change the path of an existing page to stop the blood, and then, in the future, if it makes sense, we allow the users to change the path again once we deep dive into all side effects that a path change might have

#### How should this be manually tested?

[Workspace](https://iespinoza--storecomponents.myvtex.com/admin/cms/pages)

[Existing path](https://iespinoza--storecomponents.myvtex.com/admin/cms/pages/vtex.store%402.x%3Astore.custom%23foo/)

<img width="332" alt="image" src="https://github.com/vtex-apps/admin-pages/assets/13649073/fdb563ae-bf6f-48df-89bf-2badd493ffd3">

[New Page](https://iespinoza--storecomponents.myvtex.com/admin/cms/pages/new/)

<img width="210" alt="image" src="https://github.com/vtex-apps/admin-pages/assets/13649073/94a0fa7b-2813-45eb-8ab2-1378bff0b81d">

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |


#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnh2bXNuZGU3Nmt1enF2djUzbjNxc3dqN3lydnRqcTVzeDJ1b3kzZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/eGsRMPF8q5aN049QiK/giphy.gif)
