### PR TITLE
[TCM-428] Collect "Edit content block" and "Schedule change" events

### DIFF
--- a/react/components/EditorContainer/Sidebar/BlockEditor/hooks.ts
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/hooks.ts
@@ -19,6 +19,7 @@ import {
   omitUndefined,
   throttledUpdateExtensionFromForm,
 } from './utils'
+import { createEventObject } from '../../../../utils/auditEvents'
 
 const messages = defineMessages({
   cancel: {
@@ -61,6 +62,7 @@ export const useFormHandlers: UseFormHandlers = ({
   iframeRuntime,
   intl,
   saveContent,
+  sendEventToAudit,
   setState,
   showToast,
   state,
@@ -199,6 +201,22 @@ export const useFormHandlers: UseFormHandlers = ({
       })
 
       formMeta.setWasModified(false)
+
+      if (newConfiguration.status === ConfigurationStatus.SCHEDULED) {
+        const event = createEventObject('schedule change', 'content', contentId)
+        await sendEventToAudit({
+          variables: { input: event },
+        })
+      }
+
+      const event = createEventObject(
+        'edit content block',
+        'content',
+        contentId
+      )
+      await sendEventToAudit({
+        variables: { input: event },
+      })
 
       handleFormClose()
     } catch (err) {

--- a/react/components/EditorContainer/Sidebar/BlockEditor/index.tsx
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/index.tsx
@@ -34,6 +34,7 @@ const BlockEditor = ({
   initialEditingState,
   intl,
   saveContent,
+  sendEventToAudit,
   showToast,
 }: Props) => {
   const [state, setState] = React.useReducer<
@@ -100,6 +101,7 @@ const BlockEditor = ({
     iframeRuntime,
     intl,
     saveContent,
+    sendEventToAudit,
     setState,
     showToast,
     state,

--- a/react/components/EditorContainer/Sidebar/BlockEditor/typings.d.ts
+++ b/react/components/EditorContainer/Sidebar/BlockEditor/typings.d.ts
@@ -5,6 +5,7 @@ import { ToastConsumerFunctions } from 'vtex.styleguide'
 
 import { GetDefaultConditionParams } from '../typings'
 import { ConfigurationStatus, State as FormState } from './index'
+import { SendEventToAuditMutationFn } from '../../mutations/SendEventToAudit'
 
 export type GetDefaultConfiguration = (
   params: GetDefaultConditionParams
@@ -30,6 +31,7 @@ export interface UseFormHandlersParams {
   iframeRuntime: RenderContext
   intl: InjectedIntl
   saveContent: MutationFn<SaveContentData, SaveContentVariables>
+  sendEventToAudit: SendEventToAuditMutationFn
   setState: React.Dispatch<Partial<FormState>>
   showToast: ToastConsumerFunctions['showToast']
   state: FormState

--- a/react/components/EditorContainer/Sidebar/index.tsx
+++ b/react/components/EditorContainer/Sidebar/index.tsx
@@ -15,6 +15,7 @@ import useInitialEditingState from './hooks'
 import { useModalContext } from './ModalContext'
 import styles from './styles.css'
 import Transitions from './Transitions'
+import SendEventToAuditMutation from '../mutations/SendEventToAudit'
 
 interface CustomProps {
   highlightHandler: (treePath: string | null) => void
@@ -126,12 +127,17 @@ const Sidebar: React.FunctionComponent<Props> = ({
               <Transitions.Enter condition={!!initialEditingState} from="right">
                 <SaveContentMutation>
                   {saveContent => (
-                    <BlockEditor
-                      iframeRuntime={iframeRuntime}
-                      initialEditingState={initialEditingState}
-                      saveContent={saveContent}
-                      showToast={showToast}
-                    />
+                    <SendEventToAuditMutation>
+                      {sendEventToAudit => (
+                        <BlockEditor
+                          iframeRuntime={iframeRuntime}
+                          initialEditingState={initialEditingState}
+                          saveContent={saveContent}
+                          sendEventToAudit={sendEventToAudit}
+                          showToast={showToast}
+                        />
+                      )}
+                    </SendEventToAuditMutation>
                   )}
                 </SaveContentMutation>
               </Transitions.Enter>


### PR DESCRIPTION
#### What problem is this solving?

This PR collects `Edit content block` and `Schedule change` events.

#### How should this be manually tested?

Go to this [Workspace](https://auditdev--plannerdev.myvtex.com/admin) and do _Edit Content_ action, this action will be caught and sent to Redshift where it is going to be disposed like this on its GUI
<img width="1067" alt="Screenshot 2024-06-11 at 10 29 59" src="https://github.com/vtex-apps/admin-pages/assets/43558278/0dcbed73-96da-44ae-a4ab-60db53237370">
or like this if you export the data as a JSON file
```
[
  {
    "account_name": "plannerdev",
    "date": "2024-06-08 01:02:53+00",
    "operation": "copy binding content",
    "subject_id": "",
    "author_id": "276ba720-2b3b-4135-9439-ccafd202482f",
    "application": "cms",
    "batch_id": "2024_06_08_01",
    "id": "ef7604f1-849f-46e1-b4b9-e853b69a4c88",
    "entity_name": "binding",
    "entity_before_action": "\"\"",
    "entity_after_action": "\"\""
  }
]
```

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage
https://github.com/vtex-apps/admin-pages/assets/43558278/7ce44ba9-de8a-4f0f-afdd-96611320907f


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️ | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)
