### PR TITLE
fix: modal layout overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Modal style in cms/store and not affecting site editor
+
 ## [4.56.3] - 2024-09-23
 
+### Fixed
 - Modal in admin/cms/store pages
 
 ## [4.56.2] - 2024-09-18

--- a/react/components/form/ArrayFieldTemplate/ItemForm.tsx
+++ b/react/components/form/ArrayFieldTemplate/ItemForm.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { CSSTransition } from 'react-transition-group'
 import { Button } from 'vtex.styleguide'
+import { useRuntime } from 'vtex.render-runtime'
 
 import styles from './styles.css'
 import transitionStyles from './ItemTransitions.css'
@@ -27,7 +28,11 @@ const ItemForm: React.FC<Props> = ({
   onClose,
   stackDepth,
 }) => {
-  const intl = useIntl()
+  const intl = useIntl()  
+  const { route } = useRuntime()
+
+  const isStoreSettingsPage = route.path.includes("cms/store")  
+
   return (
     <CSSTransition
       in={stackDepth < currentDepth}
@@ -43,7 +48,9 @@ const ItemForm: React.FC<Props> = ({
     >
       <div
         className={classnames(
-          `${styles['accordion-item']} bg-white bb b--light-silver absolute left-0 top-0 ph6 w-100 z-1`
+          `${styles['accordion-item']} 
+          ${isStoreSettingsPage && styles['accordion-item-settings']} 
+          bg-white bb b--light-silver absolute left-0 top-0 ph6 w-100 z-1`
         )}
       >
         {children}

--- a/react/components/form/ArrayFieldTemplate/ItemTransitions.css
+++ b/react/components/form/ArrayFieldTemplate/ItemTransitions.css
@@ -8,7 +8,7 @@
 }
 
 .item-enter-done {
-  padding: 2rem;
+  transform: translateX(18rem);
 }
 
 .item-exit {

--- a/react/components/form/ArrayFieldTemplate/styles.css
+++ b/react/components/form/ArrayFieldTemplate/styles.css
@@ -2,6 +2,11 @@
   background-color: white;
 }
 
+.accordion-item-settings {
+  padding: 2rem;
+  transform: translateX(0rem) !important;  
+}
+
 .accordion-list-container--sorting .accordion-item {
   pointer-events: none;
 }


### PR DESCRIPTION
#### What problem is this solving?

Overflow when opening modal in admin/cms/pages, not giving a good usability

Reverting the way I did for [this PR](https://github.com/vtex-apps/admin-pages/pull/470) because the way we read json schemas is the same in site-editor and the class is being shared, it caused a visual crash

#### How should this be manually tested?

Click in add favicon and check the modal

[Before](https://master--storecomponents.myvtex.com/admin/cms/store)

![image](https://github.com/user-attachments/assets/e09f31f8-f93a-4637-9eaf-bffbccee6aa6)

[After](https://customheader--storecomponents.myvtex.com/admin/cms/store)

![image](https://github.com/user-attachments/assets/42e48cac-11c1-4e4a-bbca-3e85fab44a1a)

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| ✔️  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |


#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeW44MXd2ZzdyOXoxandpcmptYTBxZWYyeW94cW9icjh0eXRuMDB5bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/B1Y73xFX4Vqqm8XdJO/giphy.gif)
