### PR TITLE
refactor: customHeader messages moved to admin-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Translations for customHeader
+
 ## [4.56.4] - 2024-10-03
 
 ### Fixed

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -595,5 +595,12 @@
   "admin/actions.enable-binding": "Активиране на конфигурацията чрез обвързване",
   "admin/actions.binding-configurations": "Обвързващи конфигурации",
   "admin/actions.binding-id": "ID за обвързване",
-  "admin/actions.binding-description": "Въведете ID за обвързване"
+  "admin/actions.binding-description": "Въведете ID за обвързване",
+  "admin/store.advancedSettings.customHeader.title": "Персонализирани заглавки",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID на заглавка",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Въведете ID, за да идентифицирате заглавката си. Пример: Моята нова персонализирана заглавка",
+  "admin/store.advancedSettings.customHeader.key.title": "Ключ на заглавка",
+  "admin/store.advancedSettings.customHeader.key.description": "Въведете ключа за вашата заглавка, като следвате принципите на HTTP. Пример: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Стойност на заглавка",
+  "admin/store.advancedSettings.customHeader.value.description": "Въведете стойността на вашия ключ, като следвате принципите на HTTP. Пример: max-age=<expire-time>"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -594,6 +594,13 @@
   "admin/actions.enable-binding": "admin/actions.enable-binding",
   "admin/actions.binding-configurations": "admin/actions.binding-configurations",
   "admin/actions.binding-id": "admin/actions.binding-id",
-  "admin/actions.binding-description": "admin/actions.binding-description"
+  "admin/actions.binding-description": "admin/actions.binding-description",
+  "admin/store.advancedSettings.customHeader.title": "admin/store.advancedSettings.customHeader.title",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "admin/store.advancedSettings.customHeader.__editorItemTitle.title",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "admin/store.advancedSettings.customHeader.__editorItemTitle.description",
+  "admin/store.advancedSettings.customHeader.key.title": "admin/store.advancedSettings.customHeader.key.title",
+  "admin/store.advancedSettings.customHeader.key.description": "admin/store.advancedSettings.customHeader.key.description",
+  "admin/store.advancedSettings.customHeader.value.title": "admin/store.advancedSettings.customHeader.value.title",
+  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.value.description"
 }
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -596,5 +596,12 @@
   "admin/actions.enable-binding": "Konfiguration durch Bindung aktivieren",
   "admin/actions.binding-configurations": "Bindungseinstellungen",
   "admin/actions.binding-id": "Bindungs-ID",
-  "admin/actions.binding-description": "Geben Sie die Bindungs-ID ein"
+  "admin/actions.binding-description": "Geben Sie die Bindungs-ID ein",
+  "admin/store.advancedSettings.customHeader.title": "Benutzerdefinierte Kopfzeilen",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Kopfzeilen-ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Geben Sie die ID ein, um Ihre Kopfzeile zu identifizieren. Beispiel: Meine neue benutzerdefinierte Kopfzeile",
+  "admin/store.advancedSettings.customHeader.key.title": "Kopfzeilen-Schlüssel",
+  "admin/store.advancedSettings.customHeader.key.description": "Geben Sie den Schlüssel für Ihre Kopfzeile ein und folgen Sie dabei den HTTP-Mustern. Beispiel: Strenge-Transport-Sicherheit",
+  "admin/store.advancedSettings.customHeader.value.title": "Kopfzeilen-Wert",
+  "admin/store.advancedSettings.customHeader.value.description": "Geben Sie den Wert für Ihren Schlüssel ein und folgen Sie dabei den HTTP-Mustern. Beispiel: Maximal-Alter=<expire-time>"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -598,5 +598,12 @@
   "admin/actions.enable-binding": "Enable configuration by binding",
   "admin/actions.binding-configurations": "Binding Settings",
   "admin/actions.binding-id": "Binding ID",
-  "admin/actions.binding-description": "Enter the binding ID"
+  "admin/actions.binding-description": "Enter the binding ID",
+  "admin/store.advancedSettings.customHeader.title": "Custom Headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Enter the ID to identify your header. Example: My new custom header",
+  "admin/store.advancedSettings.customHeader.key.title": "Header key",
+  "admin/store.advancedSettings.customHeader.key.description": "Enter the key for your header, following HTTP patterns. Example: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Header value",
+  "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -597,5 +597,12 @@
   "admin/actions.enable-binding": "Activar la configuración por vinculación",
   "admin/actions.binding-configurations": "Configuración de vinculación",
   "admin/actions.binding-id": "ID de vínculo",
-  "admin/actions.binding-description": "Introduce el ID de vínculo"
+  "admin/actions.binding-description": "Introduce el ID de vínculo",
+  "admin/store.advancedSettings.customHeader.title": "Encabezados personalizados",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID del encabezado",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Ingresa el ID para identificar tu encabezado. Ejemplo: Nuevo encabezado personalizado",
+  "admin/store.advancedSettings.customHeader.key.title": "Clave del encabezado",
+  "admin/store.advancedSettings.customHeader.key.description": "Ingresa la clave de tu encabezado, en formato HTTP. Ejemplo: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Valor del encabezado",
+  "admin/store.advancedSettings.customHeader.value.description": "Ingresa el valor de tu clave, en formato HTTP. Ejemplo: max-age=<expire-time>"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -596,5 +596,12 @@
   "admin/actions.enable-binding": "Permettre la configuration par liaison",
   "admin/actions.binding-configurations": "Configurations de liaison",
   "admin/actions.binding-id": "ID de liaison",
-  "admin/actions.binding-description": "Saisir l'ID de la liaison"
+  "admin/actions.binding-description": "Saisir l'ID de la liaison",
+  "admin/store.advancedSettings.customHeader.title": "En-têtes personnalisés",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID de l'en-tête",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Saisissez l'ID pour identifier votre en-tête. Exemple : Mon nouvel en-tête personnalisé",
+  "admin/store.advancedSettings.customHeader.key.title": "Clé de l'en-tête",
+  "admin/store.advancedSettings.customHeader.key.description": "Saisissez la clé de votre en-tête, en suivant les modèles HTTP. Exemple : Strict-Transport-Sécurité",
+  "admin/store.advancedSettings.customHeader.value.title": "Valeur de l'en-tête",
+  "admin/store.advancedSettings.customHeader.value.description": "Saisissez la valeur de votre clé, en suivant les modèles HTTP. Exemple : max-age=<expire-time>"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -595,5 +595,12 @@
   "admin/actions.enable-binding": "바인딩하여 구성 활성화",
   "admin/actions.binding-configurations": "바인딩 구성",
   "admin/actions.binding-id": "바인딩 ID",
-  "admin/actions.binding-description": "바인딩 ID 입력"
+  "admin/actions.binding-description": "바인딩 ID 입력",
+  "admin/store.advancedSettings.customHeader.title": "사용자 지정 헤더",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "헤더 ID",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "헤더를 식별할 ID를 입력합니다. 예시: 내 새 사용자 지정 헤더",
+  "admin/store.advancedSettings.customHeader.key.title": "헤더 키",
+  "admin/store.advancedSettings.customHeader.key.description": "HTTP 패턴에 따라 헤더의 키를 입력합니다. 예시: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "헤더 값",
+  "admin/store.advancedSettings.customHeader.value.description": "HTTP 패턴에 따라 키의 값을 입력합니다. 예시: max-age=<expire-time>"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -595,5 +595,12 @@
   "admin/actions.enable-binding": "Configuratie inschakelen door binding",
   "admin/actions.binding-configurations": "Bindende configuraties",
   "admin/actions.binding-id": "Bindende ID",
-  "admin/actions.binding-description": "Voer de bindende ID in"
+  "admin/actions.binding-description": "Voer de bindende ID in",
+  "admin/store.advancedSettings.customHeader.title": "Aangepaste headers",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "Header-id",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Voer de id in om uw header te identificeren. Voorbeeld: Mijn nieuwe aangepaste header",
+  "admin/store.advancedSettings.customHeader.key.title": "Headersleutel",
+  "admin/store.advancedSettings.customHeader.key.description": "Voer de sleutel in voor uw header, volgens HTTP-patronen. Voorbeeld: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Headerwaarde",
+  "admin/store.advancedSettings.customHeader.value.description": "Voer de waarde in voor uw sleutel, volgens HTTP-patronen. Voorbeeld: max-age=<expire-time>"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -597,5 +597,12 @@
   "admin/actions.enable-binding": "Habilitar configuração por vínculo",
   "admin/actions.binding-configurations": "Configurações de vínculos",
   "admin/actions.binding-id": "ID de vínculo",
-  "admin/actions.binding-description": "Insira o ID de vínculo"
+  "admin/actions.binding-description": "Insira o ID de vínculo",
+  "admin/store.advancedSettings.customHeader.title": "Cabeçalhos personalizados",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID do cabeçalho",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Insira o ID para identificar o seu cabeçalho. Exemplo: Meu novo cabeçalho personalizado",
+  "admin/store.advancedSettings.customHeader.key.title": "Chave do cabeçalho",
+  "admin/store.advancedSettings.customHeader.key.description": "Insira a chave do seu cabeçalho, seguindo os padrões HTTP. Exemplo: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "Valor do cabeçalho",
+  "admin/store.advancedSettings.customHeader.value.description": "Insira o valor de sua chave, seguindo os padrões HTTP. Exemplo: max-age=<expire-time>"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -595,5 +595,12 @@
   "admin/actions.enable-binding": "Activează configurația prin legătură",
   "admin/actions.binding-configurations": "Configurații ale legăturii",
   "admin/actions.binding-id": "ID de legătură",
-  "admin/actions.binding-description": "Introdu ID-ul de legătură"
+  "admin/actions.binding-description": "Introdu ID-ul de legătură",
+  "admin/store.advancedSettings.customHeader.title": "Anteturi personalizate",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "ID antet",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "Introdu ID-ul pentru a identifica antetul. Exemplu: Noul meu antet personalizat",
+  "admin/store.advancedSettings.customHeader.key.title": "Cheie antet",
+  "admin/store.advancedSettings.customHeader.key.description": "Introdu cheia pentru antetul tău, urmând modelele HTTP. Exemplu: Strict-Transport-Securitate",
+  "admin/store.advancedSettings.customHeader.value.title": "Valoare antet",
+  "admin/store.advancedSettings.customHeader.value.description": "Introdu valoarea pentru cheia ta, urmând modelele HTTP. Exemplu: max-age=<expire-time>"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -595,5 +595,12 @@
   "admin/actions.enable-binding": "เปิดใช้ค่ากำหนดด้วยการผูกค่า",
   "admin/actions.binding-configurations": "การกำหนดค่าการผูกข้อมูล",
   "admin/actions.binding-id": "รหัสการผูกข้อมูล",
-  "admin/actions.binding-description": "ใส่รหัสการผูกข้อมูล"
+  "admin/actions.binding-description": "ใส่รหัสการผูกข้อมูล",
+  "admin/store.advancedSettings.customHeader.title": "Header ที่ปรับใช้",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.title": "รหัส Header",
+  "admin/store.advancedSettings.customHeader.__editorItemTitle.description": "ใส่รหัสเพื่อระบุ Header ของคุณ ตัวอย่าง: Header ที่ปรับใช้ใหม่ของฉัน",
+  "admin/store.advancedSettings.customHeader.key.title": "คีย์ Header",
+  "admin/store.advancedSettings.customHeader.key.description": "ป้อนคีย์สำหรับ Header ของคุณ ทำตามรูปแบบ HTTP ตัวอย่าง: Strict-Transport-Security",
+  "admin/store.advancedSettings.customHeader.value.title": "ค่า Header",
+  "admin/store.advancedSettings.customHeader.value.description": "ใส่ค่าคีย์ของคุณ ทำตามรูปแบบ HTTP ตัวอย่าง: max-age=<expire-time>"
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently the messages are saved in admin-pages, so, I'm removing the messages from vtex.store and adding into admin-pages

#### Related to / Depends on

https://github.com/vtex-apps/store/pull/589

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWFmdnQwY2R4OXF5bjB0YTViYTEyMnducm55Y3dpazhtcGI4d2k4NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/RwTF7KAmJlkPjyKe1S/giphy.gif)
