### PR TITLE
Add get redirect with full text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allows redirect search by exact term only
+
 ## [4.57.0] - 2025-01-06
 
 ### Added
@@ -22,16 +26,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [4.56.4] - 2024-10-03
 
 ### Fixed
+
 - Modal style in cms/store and not affecting site editor
 
 ## [4.56.3] - 2024-09-23
 
 ### Fixed
+
 - Modal in admin/cms/store pages
 
 ## [4.56.2] - 2024-09-18
 
 ### Added
+
 - Empty message in pages condition template
 
 ## [4.56.1] - 2024-09-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Allows redirect search by exact term only
+- Find redirect by exact match
+
+### Removed
+
+- Infinite refetch data to find existing redirect
 
 ## [4.57.0] - 2025-01-06
 

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -241,22 +241,18 @@ const RedirectList: React.FC<Props> = ({
               })
             }
 
-            const fullTextSearchPromise = (async () => {
-              if (term.length) {
-                const { data: fullTextData } = await client.query({
-                  query: RedirectWithoutBinding,
-                  variables: {
-                    path: term,
-                  },
-                })
-                if (fullTextData?.redirect?.get) {
-                  return [fullTextData.redirect.get]
-                }
+            let result: Redirect[] = []
+            if (term.length) {
+              const { data } = await client.query({
+                query: RedirectWithoutBinding,
+                variables: {
+                  path: term,
+                },
+              })
+              if (data?.redirect?.get) {
+                result = [data.redirect.get]
               }
-              return []
-            })()
-
-            const result = await fullTextSearchPromise
+            }
 
             const combinedResults = [...filteredRedirects, ...result]
 

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -241,22 +241,21 @@ const RedirectList: React.FC<Props> = ({
               })
             }
 
-            let result: Redirect[] = []
-            if (term.length) {
+            const searchExactMatchRedirect = async (term: string) => {
+              if (!term) return []
               const { data } = await client.query({
                 query: RedirectWithoutBinding,
                 variables: {
                   path: term,
                 },
               })
-              if (data?.redirect?.get) {
-                result = [data.redirect.get]
-              }
+
+              const { get: redirectFound } = data?.redirect ?? {}
+              return redirectFound ? [redirectFound] : []
             }
+            const exactMatchRedirect = await searchExactMatchRedirect(term)
 
-            const combinedResults = [...filteredRedirects, ...result]
-
-            setRedirectList(combinedResults)
+            setRedirectList([...filteredRedirects, ...exactMatchRedirect])
 
             if (term.length) {
               setFiltered(true)

--- a/react/RedirectList.tsx
+++ b/react/RedirectList.tsx
@@ -241,18 +241,6 @@ const RedirectList: React.FC<Props> = ({
               })
             }
 
-            const innerNext = innerData?.redirect?.listRedirects.next
-            const next = innerNext ?? data?.redirect?.listRedirects.next
-
-            const listRedirectsPromise = (async () => {
-              if (!filteredRedirects.length && next) {
-                const { data } = await refetch({ limit: REDIRECTS_LIMIT, next })
-                return data.redirect.listRedirects.routes
-              } else {
-                return filteredRedirects
-              }
-            })()
-
             const fullTextSearchPromise = (async () => {
               if (term.length) {
                 const { data: fullTextData } = await client.query({
@@ -268,11 +256,11 @@ const RedirectList: React.FC<Props> = ({
               return []
             })()
 
-            const result = await Promise.race([
-              listRedirectsPromise,
-              fullTextSearchPromise,
-            ])
-            setRedirectList(result)
+            const result = await fullTextSearchPromise
+
+            const combinedResults = [...filteredRedirects, ...result]
+
+            setRedirectList(combinedResults)
 
             if (term.length) {
               setFiltered(true)

--- a/react/queries/RedirectWithoutBinding.graphql
+++ b/react/queries/RedirectWithoutBinding.graphql
@@ -1,0 +1,11 @@
+query RedirectWithoutBinding($path: String!) {
+  redirect @context(provider: "vtex.rewriter") {
+    get(path: $path) {
+      binding
+      endDate
+      from
+      to
+      type
+    }
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

For a large volume of data, searching for redirects is not feasible. This PR allows searching only for the exact term in the `from` variable. It also removes the infinite refetch data to find existing redirect.

The page starts with 1000 items loaded on the client. For these, the search does not need to be exact.

#### How should this be manually tested?

On the [Redirects management page](https://vuvasdev--cea.myvtex.com/admin/cms/redirects), it is possible to search for a `from` url that is not currently on the client. From this, an exact match search will be performed with GraphQL.

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Screenshots or example usage

`from` path to replicate the test scenario: `/conjunto-menina-blusa-flores-e-aplique-de-laco-e-short-saia-jeans-com-babados-luluzinha-3396853/p`

Request:
<img width="692" alt="image" src="https://github.com/user-attachments/assets/f6b3e1ca-e3a2-400b-ac53-5c11ddcb9a84" />

Response:
<img width="869" alt="image" src="https://github.com/user-attachments/assets/d5608026-5cf8-4c15-a20d-9d9e48a677bc" />

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| ✔️  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/9mcduSBrmMgkE/giphy.gif)
