### PR TITLE
[SFSOC-95] - Add admin flag to enable default browser navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Portuguese and English messages for useDefaultBrowserNavigation setting
+
 ## [4.57.3] - 2025-02-04
 
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -601,6 +601,8 @@
   "admin/store.advancedSettings.customHeader.key.title": "admin/store.advancedSettings.customHeader.key.title",
   "admin/store.advancedSettings.customHeader.key.description": "admin/store.advancedSettings.customHeader.key.description",
   "admin/store.advancedSettings.customHeader.value.title": "admin/store.advancedSettings.customHeader.value.title",
-  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.value.description"
+  "admin/store.advancedSettings.customHeader.value.description": "admin/store.advancedSettings.customHeader.value.description",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.title": "admin/store.advancedSettings.useDefaultBrowserNavigation.title",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "admin/store.advancedSettings.useDefaultBrowserNavigation.description"
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -607,5 +607,5 @@
   "admin/store.advancedSettings.customHeader.value.title": "Header value",
   "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>",
   "admin/store.advancedSettings.useDefaultBrowserNavigation.title": "Enable default browser navigation",
-  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Use native browser navigation instead of Render Runtime"
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Use native browser navigation instead of Render Runtime. Enable only in Fast Store accounts"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -605,5 +605,7 @@
   "admin/store.advancedSettings.customHeader.key.title": "Header key",
   "admin/store.advancedSettings.customHeader.key.description": "Enter the key for your header, following HTTP patterns. Example: Strict-Transport-Security",
   "admin/store.advancedSettings.customHeader.value.title": "Header value",
-  "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.value.description": "Enter the value for your key, following HTTP patterns. Example: max-age=<expire-time>",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.title": "Enable default browser navigation",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Use native browser navigation instead of Render Runtime"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -604,5 +604,7 @@
   "admin/store.advancedSettings.customHeader.key.title": "Chave do cabeçalho",
   "admin/store.advancedSettings.customHeader.key.description": "Insira a chave do seu cabeçalho, seguindo os padrões HTTP. Exemplo: Strict-Transport-Security",
   "admin/store.advancedSettings.customHeader.value.title": "Valor do cabeçalho",
-  "admin/store.advancedSettings.customHeader.value.description": "Insira o valor de sua chave, seguindo os padrões HTTP. Exemplo: max-age=<expire-time>"
+  "admin/store.advancedSettings.customHeader.value.description": "Insira o valor de sua chave, seguindo os padrões HTTP. Exemplo: max-age=<expire-time>",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.title": "Habilitar navegação nativa do navegador",
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Usar a navegação nativa do navegador ao invés do Render Runtime"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -606,5 +606,5 @@
   "admin/store.advancedSettings.customHeader.value.title": "Valor do cabeçalho",
   "admin/store.advancedSettings.customHeader.value.description": "Insira o valor de sua chave, seguindo os padrões HTTP. Exemplo: max-age=<expire-time>",
   "admin/store.advancedSettings.useDefaultBrowserNavigation.title": "Habilitar navegação nativa do navegador",
-  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Usar a navegação nativa do navegador ao invés do Render Runtime"
+  "admin/store.advancedSettings.useDefaultBrowserNavigation.description": "Usar a navegação nativa do navegador ao invés do Render Runtime. Use somente em contas Fast Store"
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a new flag to control bypass render runtime navigation logic, and using native browser navigation

#### How should this be manually tested?

[Workspace](https://paladinoteste--instoresetupqa.myvtex.com/)

* Load the workspace home
* Navigate to any PDP
  * You will notice a navigation progress bar at the top of the screen, indicating that it is using Render Runtime navigation solution
* Enable the new flag "Habilitar navegação nativa do navegador" can be enabled/disabled [here](https://paladinoteste--instoresetupqa.myvtex.com/admin/cms/store)
  * Wait a few minutes to avoid cached results, refresh the page, and click in the store logo, in the top left, for instance.
* Navigation progress bar should not be rendered anymore, indicating that we navigated through default browser navigation.


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| \_  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| ✔️  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |

#### Notes

Relates to [PR #597 in vtex-apps/store](https://github.com/vtex-apps/store/pull/597)

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![asd](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTNlaHZvem14M25xanBvcXI2MHRkbW9nYmE0bTJjeW1vaWdvdW5qdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMWOExnRmXt2vFS/giphy.gif)