### PR TITLE
chore: STR-969 catalog platform-flow-id (CommDev#2, Merch#3, Merch#8)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/admin-pages
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: CommDev#2,Merch#3,Merch#8
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: 60JU5OHJ
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [4.59.2] - 2026-02-09
 
 ### Fixed


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `CommDev#2,Merch#3,Merch#8` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Serviço:** Pages Admin — edição visual de componentes e conteúdo da loja. **Decisão:** README/docs CONTENT_PAGE: configurar storefront e conteúdo → **CommDev#2**, **Merch#8**, ajustes de escopo/conta **Merch#3**.

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
