### PR TITLE
fix: replace invalid `vtex.file-manager:saveFileAsync` policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update DK Catalog platform-flow-id
 
+### Fixed
+
+- Replace invalid `vtex.file-manager:saveFileAsync` policy reference with
+  the current `vtex.file-manager:file-manager-read-write` policy, which
+  fixes the `build.status: fail - Invalid policies in manifest.json:
+  vtex.file-manager:saveFileAsync: not_found` error raised by builder-hub
+  on `vtex link` / `vtex publish`.
+
 ## [4.59.2] - 2026-02-09
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
   },
   "policies": [
     {
-      "name": "vtex.file-manager:saveFileAsync"
+      "name": "vtex.file-manager:file-manager-read-write"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"


### PR DESCRIPTION
## Problema

O build do app está quebrando com:

```
build.status: fail - Invalid policies in manifest.json: vtex.file-manager:saveFileAsync: not_found
```

A entrada `vtex.file-manager:saveFileAsync` referenciada em `manifest.json` aponta para uma policy que **não existe** no app provedor `vtex.file-manager`.

## Diagnóstico

### 1. O provedor `vtex.file-manager` declara apenas uma policy

Repo `vtex/file-manager` (`vtex.file-manager@0.12.2`), arquivo `policies.json`:

```json
[
  {
    "name": "file-manager-read-write",
    "description": "Allows access to get, upload and delete files",
    "statements": [
      {
        "actions": ["get", "post", "put", "delete"],
        "effect": "allow",
        "resources": [
          "vrn:vtex.file-manager:{{region}}:{{account}}:{{workspace}}:/assets/*"
        ]
      }
    ]
  }
]
```

Existe **uma única policy declarada**, `file-manager-read-write`. Não há `saveFileAsync` no `policies.json` — em nenhuma versão atual.

### 2. `saveFileAsync` é nome de método interno, não de policy

Buscando `saveFileAsync` no repo `vtex/file-manager`, os matches são todos código C# interno do serviço dotnet:

| Arquivo | Papel |
|---|---|
| `dotnet/Service/IFileManagerService.cs` | interface do serviço |
| `dotnet/Service/FileManagerService.cs` | implementação |
| `dotnet/Controllers/RoutesController.cs` | controller que expõe a rota |
| `dotnet/service.json` | configuração IO |

Ou seja, `saveFileAsync` sempre foi o **nome de um método C#**, nunca um identificador de policy IO. A entrada no `manifest.json` é resquício histórico — provavelmente sobreviveu por anos porque o builder-hub fazia validação "soft" e tolerava referências inválidas. A validação ficou estrita e agora rejeita.

### 3. admin-pages não precisaria nem da policy direta

O único caminho de upload no código está em `react/queries/UploadFile.graphql`:

```graphql
mutation UploadFile($file: Upload!) {
  uploadFile(file: $file) {
    fileUrl
  }
}
```

Consumida por `react/components/form/ImageUploader/index.tsx` e `react/components/RichTextEditor/ImageInput.tsx`.

Essa mutation é exposta por `vtex.file-manager-graphql`, cujo `manifest.json` **já declara** a policy correta:

```json
"policies": [
  { "name": "vtex.file-manager:file-manager-read-write" },
  { "name": "outbound-access", "attrs": { ... } },
  { "name": "sphinx-is-admin" }
]
```

Como `admin-pages` já depende de `vtex.file-manager-graphql`, a cadeia de autorização para o file-manager está coberta pela ponte do graphql-proxy. admin-pages não precisaria de policy direta — uma alternativa válida seria **remover** a entrada inteira.

## A escolha desta PR

Escolhi **substituir** (e não remover) pelo nome de policy atualmente válido:

```diff
   "policies": [
     {
-      "name": "vtex.file-manager:saveFileAsync"
+      "name": "vtex.file-manager:file-manager-read-write"
     }
   ],
```

Razões:

- **Preserva a intenção original** do manifest ("este app quer acessar o file-manager"), agora com o nome correto.
- **Mantém a cadeia de policy explícita no consumidor.** Se alguém adicionar uma chamada REST direta ao file-manager no futuro (por exemplo, num builder `node/` novo), a permissão já estará declarada e auditável aqui — sem precisar caçar a policy escondida via `file-manager-graphql`.
- **Mudança mínima** (1 linha no `manifest.json`), com risco baixo de regressão.

Se preferirem **remover** a entrada (já que admin-pages é frontend-only e o acesso via GraphQL é o caminho de fato), é um follow-up trivial.

## Repos com o mesmo bug (heads up)

A busca por `vtex.file-manager:saveFileAsync` em manifests no GitHub retorna três repos com essa policy inválida:

| Repo | Visibilidade |
|---|---|
| `vtex-apps/admin-pages` | public (**este PR**) |
| `vtex/admin-cms` | private |
| `vtex/admin-pwa` | private |

Se esses dois internos ainda estão em manutenção, vão quebrar pelo mesmo motivo no próximo build. Vale ping nos times donos.

## Test plan

- [x] `manifest.json` continua sendo JSON válido (`node -e "JSON.parse(require('fs').readFileSync('manifest.json'))"`).
- [x] Entrada em `CHANGELOG.md` sob `## [Unreleased]` → `### Fixed`, conforme Keep a Changelog (e Principle VII da nova `constitution.md` na PR #488).
- [ ] DK CI `vtexio/build` passa (a validação que estava falhando antes).
- [ ] `vtex link` num workspace de dev não retorna mais o erro `Invalid policies in manifest.json`.

## Relacionado

Independente da PR #488 (bootstrap do Golden Path / SDD). Esta é um bug fix isolado para destravar o build — recomendado merge antes (ou em paralelo).


Made with [Cursor](https://cursor.com)